### PR TITLE
feat(#26, #27): Spring Security 기반 JWT 로그인 + Submodule 적용

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "backend-submodule"]
+	path = backend-submodule
+	url = https://github.com/ICT-Dev-Route/backend-submodule.git

--- a/dev-route/.gitignore
+++ b/dev-route/.gitignore
@@ -42,4 +42,3 @@ out/
 
 ##  secret.properties
 src/main/resources/application-secret.properties
-

--- a/dev-route/build.gradle
+++ b/dev-route/build.gradle
@@ -32,6 +32,11 @@ dependencies {
 	implementation 'jakarta.validation:jakarta.validation-api:3.1.0'
 	implementation 'org.hibernate.orm:hibernate-core:6.5.2.Final'
 
+	implementation 'org.springframework.security:spring-security-web:6.3.1'
+	implementation 'org.springframework.security:spring-security-config:6.3.1'
+	implementation 'org.springframework.security:spring-security-core:6.3.1'
+
+
 	implementation 'io.jsonwebtoken:jjwt-api:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-impl:0.11.2'
 	implementation 'io.jsonwebtoken:jjwt-gson:0.11.2'
@@ -50,3 +55,11 @@ dependencies {
 tasks.named('test') {
 	useJUnitPlatform()
 }
+
+processResources.dependsOn('copySecret')
+
+tasks.register('copySecret', Copy) {
+	from '../backend-submodule/application*.properties'
+	into 'src/main/resources'
+}
+

--- a/dev-route/src/main/java/com/teamdevroute/devroute/TestDataLoader.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/TestDataLoader.java
@@ -4,27 +4,26 @@ import com.teamdevroute.devroute.user.UserRepository;
 import com.teamdevroute.devroute.user.domain.User;
 import com.teamdevroute.devroute.user.enums.DevelopField;
 import com.teamdevroute.devroute.user.enums.UserRole;
-import org.hibernate.metamodel.internal.MemberResolver;
+import lombok.RequiredArgsConstructor;
 import org.springframework.boot.CommandLineRunner;
 import org.springframework.context.annotation.Profile;
+import org.springframework.security.crypto.password.PasswordEncoder;
 import org.springframework.stereotype.Component;
 
 @Profile("test")
 @Component
+@RequiredArgsConstructor
 public class TestDataLoader implements CommandLineRunner {
 
     private final UserRepository userRepository;
-
-    public TestDataLoader(UserRepository userRepository) {
-        this.userRepository = userRepository;
-    }
+    private final PasswordEncoder encoder;
 
     @Override
     public void run(String... args) throws Exception {
         final User user1 = userRepository.save(User.builder()
                 .name("윤성원")
                 .email("admin@email.com")
-                .password("password")
+                .password(encoder.encode("password"))
                 .developField(DevelopField.BACKEND.name())
                 .userRole(UserRole.ADMIN.name())
                 .goal_info("목표정보")
@@ -33,7 +32,7 @@ public class TestDataLoader implements CommandLineRunner {
         final User user2 = userRepository.save(User.builder()
                 .name("누군가")
                 .email("user@email.com")
-                .password("password")
+                .password(encoder.encode("password"))
                 .developField(DevelopField.AI.name())
                 .userRole(UserRole.USER.name())
                 .goal_info("목표정보")

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/AuthorizationProvider.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/AuthorizationProvider.java
@@ -1,8 +1,14 @@
 package com.teamdevroute.devroute.global.auth;
 
+import io.jsonwebtoken.Claims;
+
 public interface AuthorizationProvider {
 
-    UserCredential create(UserAuthContext user);
+    String create(LoginUserInfo context);
 
-    UserAuthContext parseCredential(UserCredential token);
+    Claims parseClaims(String token);
+
+    boolean validateToken(String token);
+
+    public Long getUserId(String token);
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/CustomAccessDeniedHandler.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/CustomAccessDeniedHandler.java
@@ -1,0 +1,22 @@
+package com.teamdevroute.devroute.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        String accept = request.getHeader("Accept");
+
+        if ("application/json".equals(accept)) {
+            response.setStatus(403);
+        }
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/CustomAuthenticationEntryPoint.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/CustomAuthenticationEntryPoint.java
@@ -1,0 +1,22 @@
+package com.teamdevroute.devroute.global.auth;
+
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+
+@Component
+public class CustomAuthenticationEntryPoint implements AuthenticationEntryPoint {
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        String accept = request.getHeader("Accept");
+
+        if ("application/json".equals(accept)) {
+            response.setStatus(401);
+        }
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/LoginUserInfo.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/LoginUserInfo.java
@@ -1,0 +1,17 @@
+package com.teamdevroute.devroute.global.auth;
+
+import lombok.*;
+
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
+@Getter
+@Setter
+public class LoginUserInfo {
+    private Long id;
+    private String email;
+    private String name;
+    private String password;
+    private String role;
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/UserAuthContext.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/UserAuthContext.java
@@ -1,7 +1,0 @@
-package com.teamdevroute.devroute.global.auth;
-
-public record UserAuthContext(
-        String name,
-        String role
-) {
-}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/filter/JwtAuthFilter.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/filter/JwtAuthFilter.java
@@ -1,0 +1,47 @@
+package com.teamdevroute.devroute.global.auth.filter;
+
+import com.teamdevroute.devroute.global.auth.jwt.JwtUtils;
+import com.teamdevroute.devroute.user.service.CustomUserDetailsService;
+import jakarta.servlet.FilterChain;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import java.io.IOException;
+
+@RequiredArgsConstructor
+public class JwtAuthFilter extends OncePerRequestFilter {
+
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtils jwtUtils;
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        String authorizationHeader = request.getHeader("Authorization");
+
+        if(authorizationHeader != null && authorizationHeader.startsWith("Bearer ")) {
+            String token = authorizationHeader.substring(7);
+            if(jwtUtils.validateToken(token)) {
+                Long id = jwtUtils.getUserId(token);
+
+                UserDetails userDetails = customUserDetailsService.loadUserByUsername(id.toString());
+
+                if(userDetails != null) {
+                    //UserDetsils, Password, Role -> 접근권한 인증 Token 생성
+                    UsernamePasswordAuthenticationToken usernamePasswordAuthenticationToken =
+                            new UsernamePasswordAuthenticationToken(userDetails, null, userDetails.getAuthorities());
+
+                    //현재 Request의 Security Context에 접근권한 설정
+                    SecurityContextHolder.getContext().setAuthentication(usernamePasswordAuthenticationToken);
+                }
+            }
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/jwt/JwtUtils.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/jwt/JwtUtils.java
@@ -1,58 +1,84 @@
 package com.teamdevroute.devroute.global.auth.jwt;
 
 import com.teamdevroute.devroute.global.auth.AuthorizationProvider;
-import com.teamdevroute.devroute.global.auth.UserAuthContext;
+import com.teamdevroute.devroute.global.auth.LoginUserInfo;
 import com.teamdevroute.devroute.global.auth.UserCredential;
-import io.jsonwebtoken.Claims;
-import io.jsonwebtoken.Jwts;
+import io.jsonwebtoken.*;
 import io.jsonwebtoken.io.Decoders;
 import io.jsonwebtoken.security.Keys;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.stereotype.Component;
 
+import java.security.Key;
+import java.time.ZonedDateTime;
 import java.util.Date;
 
+@Slf4j
 @Component
 public class JwtUtils implements AuthorizationProvider {
 
     private static final String USER_NAME = "name";
     private static final String USER_ROLE = "role";
 
-    private final String secretKey;
-    private final Long expirationMilliSec;
+    private final Key key;
+    private final long accessTokenExpTime;
 
     public JwtUtils(@Value("${devroute.auth.jwt.secret}") String secretKey,
-                    @Value("${devroute.auth.jwt.expiration}") Long expirationMilliSec
+                    @Value("${devroute.auth.jwt.expiration}") long accessTokenExpTime
     ) {
-        this.secretKey = secretKey;
-        this.expirationMilliSec = expirationMilliSec;
+        byte[] keyBytes = Decoders.BASE64.decode(secretKey);
+        this.key = Keys.hmacShaKeyFor(keyBytes);
+        this.accessTokenExpTime = accessTokenExpTime;
     }
 
     @Override
-    public UserCredential create(UserAuthContext context) {
-        Date now = new Date();
-        Date validity = new Date(now.getTime() + expirationMilliSec);
+    public String create(LoginUserInfo context) {
+        Claims claims = Jwts.claims();
+        claims.put("memberId", context.getId());
+        claims.put("email", context.getEmail());
+        claims.put("role", context.getRole());
 
-        String tokenValue = Jwts.builder()
-                .claim(USER_NAME, context.name())
-                .claim(USER_ROLE, context.role())
-                .setIssuedAt(now)
-                .setExpiration(validity)
-                .signWith(Keys.hmacShaKeyFor(secretKey.getBytes()))
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime tokenValidity = now.plusSeconds(accessTokenExpTime);
+
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(Date.from(now.toInstant()))
+                .setExpiration(Date.from(tokenValidity.toInstant()))
+                .signWith(key, SignatureAlgorithm.HS256)
                 .compact();
-        return new UserCredential(tokenValue);
     }
 
     @Override
-    public UserAuthContext parseCredential(UserCredential token) {
-        Claims claims = Jwts.parserBuilder()
-                .setSigningKey(Keys.hmacShaKeyFor(Decoders.BASE64URL.decode(secretKey)))
-                .build()
-                .parseClaimsJws(token.authorization())
-                .getBody();
-        return new UserAuthContext(
-                claims.get(USER_NAME, String.class),
-                claims.get(USER_ROLE, String.class)
-        );
+    public Claims parseClaims(String token) {
+        try {
+            return Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token).getBody();
+        } catch (ExpiredJwtException e) {
+            return e.getClaims();
+        }
+    }
+
+    @Override
+    public boolean validateToken(String token) {
+        try{
+            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
+            return true;
+        } catch(io.jsonwebtoken.security.SecurityException | MalformedJwtException e) {
+            log.info("Invalid JWT Token", e);
+        } catch (ExpiredJwtException e) {
+            log.info("Expired JWT Token", e);
+        } catch (UnsupportedJwtException e) {
+            log.info("Unsupported JWT Token", e);
+        } catch (IllegalArgumentException e) {
+            log.info("JWT claims string is empty.", e);
+        }
+        return false;
+    }
+
+    @Override
+    public Long getUserId(String token) {
+        return parseClaims(token).get("memberId", Long.class);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/PasswordEncoderConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/PasswordEncoderConfig.java
@@ -1,0 +1,13 @@
+package com.teamdevroute.devroute.global.config;
+
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+
+@Configuration
+public class PasswordEncoderConfig {
+    @Bean
+    public BCryptPasswordEncoder passwordEncoder() {
+        return new BCryptPasswordEncoder();
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
@@ -1,0 +1,54 @@
+package com.teamdevroute.devroute.global.config;
+
+import com.teamdevroute.devroute.global.auth.CustomAccessDeniedHandler;
+import com.teamdevroute.devroute.global.auth.CustomAuthenticationEntryPoint;
+import com.teamdevroute.devroute.global.auth.filter.JwtAuthFilter;
+import com.teamdevroute.devroute.global.auth.jwt.JwtUtils;
+import com.teamdevroute.devroute.user.service.CustomUserDetailsService;
+import lombok.AllArgsConstructor;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.security.config.Customizer;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
+import org.springframework.security.config.annotation.web.configurers.HeadersConfigurer;
+import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.web.SecurityFilterChain;
+import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@Configuration
+@EnableWebSecurity
+@AllArgsConstructor
+public class SecurityConfig {
+    private final CustomUserDetailsService customUserDetailsService;
+    private final JwtUtils jwtUtils;
+    private final CustomAccessDeniedHandler accessDeniedHandler;
+    private final CustomAuthenticationEntryPoint authenticationEntryPoint;
+
+    private static final String[] AUTH_WHITELIST = {
+        "/login"
+    };
+
+    @Bean
+    public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
+        http
+                .csrf(AbstractHttpConfigurer::disable)
+                .cors(Customizer.withDefaults())
+                .headers((headers) -> headers.frameOptions(HeadersConfigurer.FrameOptionsConfig::disable))
+                .sessionManagement(sessionManagement -> sessionManagement.sessionCreationPolicy(
+                        SessionCreationPolicy.STATELESS
+                ))
+                .formLogin(AbstractHttpConfigurer::disable)
+                .httpBasic(AbstractHttpConfigurer::disable)
+                .addFilterBefore(new JwtAuthFilter(customUserDetailsService, jwtUtils), UsernamePasswordAuthenticationFilter.class)
+                .exceptionHandling((exceptionHandling) -> exceptionHandling
+                        .authenticationEntryPoint(authenticationEntryPoint)
+                        .accessDeniedHandler(accessDeniedHandler))
+                .authorizeHttpRequests(authorize -> authorize
+                        .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .anyRequest().authenticated());
+
+        return http.build();
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/exception/UserNotFoundException.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/exception/UserNotFoundException.java
@@ -1,0 +1,6 @@
+package com.teamdevroute.devroute.global.exception;
+
+public class UserNotFoundException extends RuntimeException {
+    public UserNotFoundException() {
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
@@ -1,12 +1,10 @@
 package com.teamdevroute.devroute.user;
 
-import com.teamdevroute.devroute.global.auth.AuthorizationProvider;
-import com.teamdevroute.devroute.global.auth.UserAuthContext;
-import com.teamdevroute.devroute.global.auth.UserCredential;
 import com.teamdevroute.devroute.user.dto.UserCreateRequest;
 import com.teamdevroute.devroute.user.dto.UserCreateResponse;
 import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.PostMapping;
@@ -14,14 +12,13 @@ import org.springframework.web.bind.annotation.RequestBody;
 
 import java.net.URI;
 
+@Slf4j
 @Controller
 public class UserController {
     private final UserService userService;
-    private final AuthorizationProvider authorizationProvider;
 
-    public UserController(UserService userService, AuthorizationProvider authorizationProvider) {
+    public UserController(UserService userService) {
         this.userService = userService;
-        this.authorizationProvider = authorizationProvider;
     }
 
     @PostMapping("/signup")
@@ -35,9 +32,9 @@ public class UserController {
             @RequestBody UserLoginRequest loginRequest,
             HttpServletResponse response
     ) {
-        UserAuthContext userAuthContext = userService.loginByEmailAndPassword(loginRequest);
-        UserCredential userCredential = authorizationProvider.create(userAuthContext);
-        Cookie cookie = new Cookie("token", userCredential.authorization());
+        String token = userService.login(loginRequest);
+        log.info("토큰: " + token);
+        Cookie cookie = new Cookie("token", token);
         cookie.setHttpOnly(true);
         cookie.setPath("/");
         response.addCookie(cookie);

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserControllerAdvice.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserControllerAdvice.java
@@ -1,0 +1,14 @@
+package com.teamdevroute.devroute.user;
+
+import com.teamdevroute.devroute.global.exception.UserNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class UserControllerAdvice {
+    @ExceptionHandler(UserNotFoundException.class)
+    public ResponseEntity handleNotFoundUserException(UserNotFoundException e) {
+        return ResponseEntity.badRequest().body("유저를 찾을 수 없습니다.");
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserLoginRequest.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserLoginRequest.java
@@ -1,8 +1,20 @@
 package com.teamdevroute.devroute.user;
 
-public record UserLoginRequest(
-        String email,
-        String password
-) {
+import jakarta.validation.constraints.Email;
+import jakarta.validation.constraints.NotNull;
+import lombok.AllArgsConstructor;
+import lombok.Data;
+import lombok.NoArgsConstructor;
 
+@Data
+@AllArgsConstructor
+@NoArgsConstructor
+public class UserLoginRequest {
+
+    @NotNull(message = "이메일은 null 일 수 없습니다.")
+    @Email
+    private String email;
+
+    @NotNull(message = "비밀번호는 null 일 수 없습니다.")
+    private String password;
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserRepository.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserRepository.java
@@ -8,4 +8,5 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmailAndPassword(String email, String password);
+    Optional<User> findByEmail(String email);
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/domain/CustomUserDetails.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/domain/CustomUserDetails.java
@@ -1,0 +1,60 @@
+package com.teamdevroute.devroute.user.domain;
+
+import com.teamdevroute.devroute.global.auth.LoginUserInfo;
+import lombok.Getter;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.GrantedAuthority;
+import org.springframework.security.core.authority.SimpleGrantedAuthority;
+import org.springframework.security.core.userdetails.UserDetails;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Getter
+@RequiredArgsConstructor
+public class CustomUserDetails implements UserDetails {
+
+    private final LoginUserInfo user;
+
+    @Override
+    public Collection<? extends GrantedAuthority> getAuthorities() {
+        List<String> roles = new ArrayList<>();
+        roles.add("ROLE_" + user.getRole());
+
+        return roles.stream()
+                .map(SimpleGrantedAuthority::new)
+                .collect(Collectors.toList());
+    }
+
+    @Override
+    public String getPassword() {
+        return user.getPassword();
+    }
+
+    @Override
+    public String getUsername() {
+        return null;
+    }
+
+    @Override
+    public boolean isAccountNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isAccountNonLocked() {
+        return true;
+    }
+
+    @Override
+    public boolean isCredentialsNonExpired() {
+        return true;
+    }
+
+    @Override
+    public boolean isEnabled() {
+        return true;
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/service/CustomUserDetailsService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/service/CustomUserDetailsService.java
@@ -1,0 +1,36 @@
+package com.teamdevroute.devroute.user.service;
+
+import com.teamdevroute.devroute.global.auth.LoginUserInfo;
+import com.teamdevroute.devroute.user.UserRepository;
+import com.teamdevroute.devroute.user.domain.CustomUserDetails;
+import com.teamdevroute.devroute.user.domain.User;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@Transactional(readOnly = true)
+@RequiredArgsConstructor
+public class CustomUserDetailsService implements UserDetailsService {
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String id) throws UsernameNotFoundException {
+        User user = userRepository.findById(Long.parseLong(id))
+                .orElseThrow(() -> new UsernameNotFoundException("해당하는 유저가 없습니다."));
+
+        LoginUserInfo userInfo = LoginUserInfo.builder()
+                .id(user.getId())
+                .email(user.getEmail())
+                .password(user.getPassword())
+                .name(user.getName())
+                .role(user.getUserRole())
+                .build();
+
+        return new CustomUserDetails(userInfo);
+    }
+}

--- a/dev-route/src/main/resources/application.properties
+++ b/dev-route/src/main/resources/application.properties
@@ -18,8 +18,6 @@ spring.sql.init.mode=always
 spring.sql.init.platform=mysql
 spring.sql.init.data-locations=classpath:data.sql
 
-devroute.auth.jwt.secret=ZGV2cm91dGUgaXMgaGVyZSBpbiBzZWpvbmcgdW5pdmVyc2l0eQ==
-devroute.auth.jwt.expiration=86400000
 crawling.link.jobplanet=https://www.jobplanet.co.kr/companies?industry_id=700&_rs_act=industries&_rs_con=gnb&_rs_element=category
 
 #API URL


### PR DESCRIPTION
## 🔎 작업 내용

- jwt secretket와 만료시간 등을 저장하는 `Submodule` 추가
- `Spring Security` 추가
- Jwt용 `Filter` 추가
- `Security Config` 추가
- `WHITELIST_URL`을 통해 인증이 필요없는 url 설정

### 설명
1. `MemberAuthContext`: 유저의 인증을 위한 정보를 저장
2. `JwtAuthFilter`: 요청에 담긴 jwt를 검증하여 userDetail 생성 및 현재 요청의 접근 허용
3. `JwtUtil`: Jwt 토큰 생성 및 Validation
4. `AuthorizationProvider`: JwtUtil의 인터페이스
5. `CustomAccessDeniedHandler`: 액서스 거부 시 핸들러 (SecurityConfig에서 설정)
6. `CustomAuthenticationEntryPoint`: 엔트리 포인트의 인증 예외처리
7. `SecurityConfig`: 스프링 시큐리티 설정
8. `MemberControllerAdvice`: Member 도메인 컨트롤러의 예외처리 통합 관리

<br/>

## 🔧 앞으로의 과제
- SSO 로그인 구현

  <br/>

## ➕ 이슈 링크


<br/>