### PR TITLE
[#25]feat: 기업 이름 기반 점핏 채용공고 크롤링

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawling.java
@@ -1,0 +1,137 @@
+package com.teamdevroute.devroute.crawling;
+
+import com.teamdevroute.devroute.crawling.dto.CrawledRecruitmentDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.json.simple.JSONObject;
+import org.jsoup.Jsoup;
+import org.jsoup.nodes.Document;
+import org.openqa.selenium.By;
+import org.openqa.selenium.JavascriptExecutor;
+import org.openqa.selenium.WebDriver;
+import org.openqa.selenium.WebElement;
+import org.openqa.selenium.support.ui.WebDriverWait;
+import org.springframework.stereotype.Component;
+
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.List;
+
+@Component
+@Slf4j
+public class RecruitmentCrawling {
+
+    private final static int CRAWLING_RECRUIT_NUM_MAX = 10;
+    private final static String JUMPIT_URL = "https://www.jumpit.co.kr/positions?jobCategory=1&sort=rsp_rate";
+
+    private WebDriverUtil webDriverUtil;
+
+    public RecruitmentCrawling(WebDriverUtil webDriverUtil) {
+        this.webDriverUtil = webDriverUtil;
+    }
+
+    public List<CrawledRecruitmentDto> crawlingJUMPIT(List<String> enterpriseNames) {
+        webDriverUtil.getChromeDriver(JUMPIT_URL);
+        WebDriver driver = webDriverUtil.getDriver();
+
+        // 정보를 담을 JSON
+        JSONObject info = new JSONObject();
+
+        JavascriptExecutor js = (JavascriptExecutor) driver;
+
+        // 현재 페이지의 소스코드 가져오기
+        Document doc = Jsoup.parse(driver.getPageSource());
+
+        // 상위 10개 기업 이름 및 연봉 가져오기
+        List<String> enterpriseSalaries = new ArrayList<>();
+        List<String> enterpriseGrades = new ArrayList<>();
+        List<String> enterpriseLogo = new ArrayList<>();
+
+        driver.manage().window().maximize();
+
+        List<CrawledRecruitmentDto> crawledRecruitmentDtoList = new ArrayList<>(10);
+
+        try {
+            for (int i = 0; i < enterpriseNames.size(); i++) {
+                int idx;
+                WebElement input = driver.findElement(By.tagName("input"));
+                input.sendKeys(enterpriseNames.get(i));
+
+                driver.findElement(By.className("search_button")).click();
+
+                Thread.sleep(100);
+
+                for (int j = 1; j <= CRAWLING_RECRUIT_NUM_MAX; j++) {
+                    String css = "body > main > div > section.sc-c12e57e5-3.gjgpzi > section > div:nth-child(" + j + ") > a > div.sc-15ba67b8-0.kkQQfR > div > div";
+
+
+                    WebElement element = driver.findElement(By.cssSelector(css));
+                    if(element == null){
+                        break;
+                    }
+
+                    String companyName = element.getText();
+                    log.info("회사 이름: " + companyName);
+                    crawledRecruitmentDtoList.add(
+                            CrawledRecruitmentDto.builder().companyName(companyName).build()
+                    );
+                }
+
+                idx = 0;
+                for (WebElement element : driver.findElements(By.className("position_card_info_title"))) {
+                    if(idx == CRAWLING_RECRUIT_NUM_MAX){
+                        break;
+                    }
+
+                    String title = element.getText();
+                    log.info("제목: " + title);
+                    crawledRecruitmentDtoList.get(idx++).setTitle(title);
+                }
+
+                idx = 0;
+                for(int j = 1; j <= CRAWLING_RECRUIT_NUM_MAX; j++) {
+                    if(idx == CRAWLING_RECRUIT_NUM_MAX){
+                        break;
+                    }
+                    String css = "body > main > div > section.sc-c12e57e5-3.gjgpzi > section > div:nth-child(" + j + ") > a > div.sc-15ba67b8-0.kkQQfR > ul.sc-15ba67b8-1.iFMgIl";
+                    WebElement ul = driver.findElement(By.cssSelector(css));
+
+                    List<WebElement> ilList = ul.findElements(By.tagName("li"));
+                    List<String> techList = new ArrayList<>();
+
+                    ilList.forEach(e -> techList.add(e.getText()));
+
+                    log.info(techList.toString());
+                    crawledRecruitmentDtoList.get(idx++).setTechList(techList);
+                }
+
+                idx = 0;
+                for(int j= 1;j<=CRAWLING_RECRUIT_NUM_MAX;j++){
+                    if(idx == CRAWLING_RECRUIT_NUM_MAX){
+                        break;
+                    }
+                    String css = "body > main > div > section.sc-c12e57e5-3.gjgpzi > section > div:nth-child(" + j + ") > a > div.sc-15ba67b8-0.kkQQfR > ul.sc-15ba67b8-1.cdeuol";
+                    WebElement ul = driver.findElement(By.cssSelector(css));
+
+                    List<WebElement> ilList = ul.findElements(By.tagName("li"));
+                    log.info("il 크기: "+ ilList.size());
+                    String area = ilList.get(0).getText();
+                    String career = ilList.get(1).getText();
+                    crawledRecruitmentDtoList.get(idx).setArea(area);
+                    crawledRecruitmentDtoList.get(idx++).setCareer(career);
+                }
+            }
+
+            log.info(crawledRecruitmentDtoList.toString());
+
+
+        } catch (Exception e) {
+            e.printStackTrace();
+        }
+
+        webDriverUtil.closeChromeDriver();
+
+        return crawledRecruitmentDtoList;
+    }
+}
+

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledRecruitmentDto.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledRecruitmentDto.java
@@ -1,0 +1,28 @@
+package com.teamdevroute.devroute.crawling.dto;
+
+import lombok.*;
+
+import java.util.List;
+
+@Getter
+@Setter
+@NoArgsConstructor
+@ToString
+public class CrawledRecruitmentDto {
+    private String title;
+    private String imageUrl;
+    private String companyName;
+    private List<String> techList;
+    private String area;
+    private String career;
+
+    @Builder
+    public CrawledRecruitmentDto(String title, String imageUrl, String companyName, List<String> techList, String area, String career) {
+        this.title = title;
+        this.imageUrl = imageUrl;
+        this.companyName = companyName;
+        this.techList = techList;
+        this.area = area;
+        this.career = career;
+    }
+}

--- a/dev-route/src/main/resources/data.sql
+++ b/dev-route/src/main/resources/data.sql
@@ -2,8 +2,3 @@ INSERT INTO company (name, logo_url, click_count, date_created, date_updated)
 VALUES ('Company A', 'http://logoA.com', 100, '2024/07/11 12:12:00', '2024/07/11 12:12:00'),
        ('Company B', 'http://logoB.com', 200, '2024/07/11 12:13:00', '2024/07/11 12:13:00'),
        ('Company C', 'http://logoC.com', 300, '2024/07/11 12:14:00', '2024/07/11 12:14:00');
-
-INSERT INTO user (development_field, email,password,name,login_type, user_role)
-    VALUE ('AI', 'abc@email.com', '1234', 'user', 'NORMAL', 'USER');
-INSERT INTO user (development_field, email,password,name,login_type, user_role)
-    VALUE ('BACKEND', 'abc@email.com', '1234', 'user', 'NORMAL', 'ADMIN');

--- a/dev-route/src/test/java/com/teamdevroute/devroute/crawling/CrawlingTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/crawling/CrawlingTest.java
@@ -1,9 +1,16 @@
 package com.teamdevroute.devroute.crawling;
 
+import com.teamdevroute.devroute.crawling.dto.CrawledRecruitmentDto;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 public class CrawlingTest {
@@ -29,5 +36,14 @@ public class CrawlingTest {
         crawling.getThirtyCompany(1);
         crawling.getThirtyCompany(2);
         crawling.getThirtyCompany(3);
+    }
+
+    @Test
+    void get_recruitment() {
+        List<String> companyNames = new ArrayList<>(Arrays.asList("삼성"));
+
+        RecruitmentCrawling recruitmentCrawling = new RecruitmentCrawling(webDriverUtil);
+        List<CrawledRecruitmentDto> dtoList = recruitmentCrawling.crawlingJUMPIT(companyNames);
+        assertThat(dtoList.size()).isEqualTo(10);
     }
 }

--- a/dev-route/src/test/java/com/teamdevroute/devroute/user/UserServiceTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/user/UserServiceTest.java
@@ -19,8 +19,7 @@ import java.util.Map;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatCode;
 
-@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.DEFINED_PORT)
-@DirtiesContext(classMode = DirtiesContext.ClassMode.BEFORE_EACH_TEST_METHOD)
+@SpringBootTest
 @ActiveProfiles("test")
 public class UserServiceTest {
 


### PR DESCRIPTION
## 🔎 작업 내용

- 기업 이름을 기반으로 점핏에서 채용공고를 크롤링
- RecruitmentCrawling에서 채용공고 크롤링 진행
- ❗ **데이터 베이스에 저장되는 코드는 미포함**

<br/>

## 🔧 앞으로의 과제

- 크롤링 코드 리펙터링
- 크롤링된 코드 DB에 저장하는 로직
- @Scheduled 사용하기

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>