### PR TITLE
[#25]feat: 상위 30개 기업 검색 후, 검색 결과로 채용공고 검색

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyCrawlingService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyCrawlingService.java
@@ -2,6 +2,7 @@ package com.teamdevroute.devroute.crawling;
 
 import com.teamdevroute.devroute.company.Company;
 import com.teamdevroute.devroute.company.CompanyRepository;
+import com.teamdevroute.devroute.crawling.dto.CrawledCompanyDto;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
@@ -15,19 +16,19 @@ public class CompanyCrawlingService {
         this.companyRepository = companyRepository;
     }
 
-    public void createCompany(
-            List<String> enterpriseNames,
-            List<String> enterpriseSalaries,
-            List<String> enterpriseGrades,
-            List<String> enterpriseLogos
-    ) {
+    public void createCompany(CrawledCompanyDto crawledCompanyDto) {
+        List<String> enterpriseNames = crawledCompanyDto.getEnterpriseNames();
+        List<String> enterpriseSalaries = crawledCompanyDto.getEnterpriseSalaries();
+        List<String> enterpriseGrades = crawledCompanyDto.getEnterpriseGrades();
+        List<String> enterpriseLogo = crawledCompanyDto.getEnterpriseLogo();
+
         for(int i=0;i<enterpriseNames.size();i++) {
             companyRepository.save(
                     Company.builder()
                     .name(enterpriseNames.get(i))
                     .averageSalary(enterpriseSalaries.get(i))
                     .grade(Double.parseDouble(enterpriseGrades.get(i)))
-                    .logoUrl(enterpriseLogos.get(i))
+                    .logoUrl(enterpriseLogo.get(i))
                     .build()
             );
         }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
@@ -1,0 +1,31 @@
+package com.teamdevroute.devroute.crawling;
+
+import com.teamdevroute.devroute.crawling.dto.CrawledCompanyDto;
+import com.teamdevroute.devroute.crawling.dto.CrawledRecruitmentDto;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+
+@Slf4j
+@Component
+public class CompanyRecruitmentCrawling {
+
+    private final CompanyCrawling companyCrawling;
+    private final RecruitmentCrawling recruitmentCrawling;
+
+    public CompanyRecruitmentCrawling(CompanyCrawling companyCrawling, RecruitmentCrawling recruitmentCrawling) {
+        this.companyCrawling = companyCrawling;
+        this.recruitmentCrawling = recruitmentCrawling;
+    }
+
+    @Scheduled(fixedRate = 60000)
+    public void companyAndRecruitmentCrawling() {
+        CrawledCompanyDto crawledCompanyDto = companyCrawling.getCompanyThreePage();
+        log.info(crawledCompanyDto.toString());
+        recruitmentCrawling.crawlingJUMPIT(crawledCompanyDto.getEnterpriseNames());
+    }
+
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawling.java
@@ -25,6 +25,7 @@ public class RecruitmentCrawling {
     private final static String JUMPIT_URL = "https://www.jumpit.co.kr/positions?jobCategory=1&sort=rsp_rate";
 
     private WebDriverUtil webDriverUtil;
+    private RecruitmentCrawlingService recruitmentCrawlingService;
 
     public RecruitmentCrawling(WebDriverUtil webDriverUtil) {
         this.webDriverUtil = webDriverUtil;
@@ -41,11 +42,6 @@ public class RecruitmentCrawling {
 
         // 현재 페이지의 소스코드 가져오기
         Document doc = Jsoup.parse(driver.getPageSource());
-
-        // 상위 10개 기업 이름 및 연봉 가져오기
-        List<String> enterpriseSalaries = new ArrayList<>();
-        List<String> enterpriseGrades = new ArrayList<>();
-        List<String> enterpriseLogo = new ArrayList<>();
 
         driver.manage().window().maximize();
 
@@ -121,9 +117,6 @@ public class RecruitmentCrawling {
                     crawledRecruitmentDtoList.get(idx++).setCareer(career);
                 }
             }
-
-            log.info(crawledRecruitmentDtoList.toString());
-
 
         } catch (Exception e) {
             e.printStackTrace();

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawlingService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawlingService.java
@@ -1,0 +1,23 @@
+package com.teamdevroute.devroute.crawling;
+
+import com.teamdevroute.devroute.crawling.dto.CrawledRecruitmentDto;
+import com.teamdevroute.devroute.recruitment.repository.RecruitmentRepository;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Service;
+
+import java.util.List;
+
+@Service
+@Slf4j
+@RequiredArgsConstructor
+public class RecruitmentCrawlingService {
+
+    private RecruitmentRepository recruitmentRepository;
+
+    // TODO 채용공고 엔티티 수정 후 구현
+    public void createRecruitment(List<CrawledRecruitmentDto> crawledRecruitmentDtoList) {
+
+
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledCompanyDto.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledCompanyDto.java
@@ -1,0 +1,38 @@
+package com.teamdevroute.devroute.crawling.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import lombok.ToString;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@Getter
+@ToString
+public class CrawledCompanyDto {
+
+    private List<String> enterpriseNames;
+    private List<String> enterpriseSalaries;
+    private List<String> enterpriseGrades;
+    private List<String> enterpriseLogo;
+
+    public CrawledCompanyDto() {
+
+    }
+
+    @Builder
+    public CrawledCompanyDto(List<String> enterpriseNames, List<String> enterpriseSalaries, List<String> enterpriseGrades, List<String> enterpriseLogo) {
+        this.enterpriseNames = enterpriseNames;
+        this.enterpriseSalaries = enterpriseSalaries;
+        this.enterpriseGrades = enterpriseGrades;
+        this.enterpriseLogo = enterpriseLogo;
+    }
+
+    public void mergeCrawledCompanyDto(CrawledCompanyDto into) {
+        this.enterpriseNames.addAll(into.enterpriseNames);
+        this.enterpriseGrades.addAll(into.enterpriseGrades);
+        this.enterpriseLogo.addAll(into.enterpriseLogo);
+        this.enterpriseSalaries.addAll(into.enterpriseSalaries);
+    }
+}

--- a/dev-route/src/test/java/com/teamdevroute/devroute/crawling/CrawlingTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/crawling/CrawlingTest.java
@@ -33,9 +33,7 @@ public class CrawlingTest {
     @Test
     void get_thirty_companies() throws InterruptedException {
         CompanyCrawling crawling = new CompanyCrawling(webDriverUtil, companyCrawlingService);
-        crawling.getThirtyCompany(1);
-        crawling.getThirtyCompany(2);
-        crawling.getThirtyCompany(3);
+        crawling.getCompanyThreePage();
     }
 
     @Test


### PR DESCRIPTION
## 🔎 작업 내용

- `CompanyCrawling`과 `RecruitmentCrawling` 에서 **각 크롤링 기능 모듈화**
- `CompanyRecruitmentCrawling`에서 **모듈화된 크롤링 기능을 한 번에 수행**
    - `@Scheduled`를 통해 **매일 자정 업데이트 되도록 수정**
- `CrawledCompanyDto`와 `CrawledRecruitmentDto`에서 크롤링된 정보를 가짐

<br/>

## 🔧 앞으로의 과제

- Recruitment 엔티티 어트리뷰트 수정

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>