### PR TITLE
[#34] feat : naver, google 로그인 구현

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
@@ -1,10 +1,9 @@
 package com.teamdevroute.devroute.global.auth;
 
-import com.google.gson.JsonElement;
+import com.google.gson.Gson;
 import com.google.gson.JsonObject;
 import com.google.gson.JsonParser;
 import com.teamdevroute.devroute.user.dto.UserAuthResponse;
-import com.teamdevroute.devroute.user.dto.UserCreateResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.http.HttpEntity;
@@ -16,36 +15,54 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.io.BufferedReader;
-import java.io.BufferedWriter;
-import java.io.InputStreamReader;
-import java.io.OutputStreamWriter;
-import java.net.HttpURLConnection;
-import java.net.URL;
+import java.util.HashMap;
+import java.util.Map;
 
 @Component
 @RequiredArgsConstructor
 public class Oauth2Util {
 
+    // kakao
     @Value("${kakao.api_key}")
-    private String kakaoApiKey;
+    private String KAKAO_API_KEY;
 
     @Value("${kakao.redirect_uri}")
-    private String kakaoRedirectUri;
+    private String KAKAO_REDIRECT_URI;
 
-    private String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
-    private String KAKAO_AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
+    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
+    private final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
+    private final String KAKAO_AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
+
+    // google
+    @Value("${google.client.id}")
+    private String GOOGLE_CLIENT_ID;
+
+    @Value("${google.redirect.uri}")
+    private String GOOGLE_REDIRECT_URL;
+
+    @Value("${google.client.secret}")
+    private String GOOGLE_CLIENT_SECRET;
+
+    private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
+    private final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
+    private final String GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 
     private static final RestTemplate restTemplate = new RestTemplate();
 
     public String getKakaoRedirectUrl() {
-        String KAKAO_AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
-
         String url = KAKAO_AUTHORIZATION_URL
-                + "?client_id=" + kakaoApiKey
-                + "&redirect_uri=" + kakaoRedirectUri
+                + "?client_id=" + KAKAO_API_KEY
+                + "&redirect_uri=" + KAKAO_REDIRECT_URI
                 + "&response_type=code";
+        return url;
+    }
+
+    public String getGoogleRedirectUrl() {
+        String url = GOOGLE_AUTHORIZATION_URL
+                + "?client_id=" + GOOGLE_CLIENT_ID
+                + "&redirect_uri=" + GOOGLE_REDIRECT_URL
+                + "&response_type=code&scope=email%20profile%20openid" +
+                "&access_type=offline";
         return url;
     }
 
@@ -55,11 +72,11 @@ public class Oauth2Util {
 
         MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
         params.add("grant_type", "authorization_code");
-        params.add("client_id", kakaoApiKey);
-        params.add("redirect_uri", kakaoRedirectUri);
+        params.add("client_id", KAKAO_API_KEY);
+        params.add("redirect_uri", KAKAO_REDIRECT_URI);
         params.add("code", authorizationCode);
 
-        HttpEntity<MultiValueMap<String,String>> kakaoTokenRequest = new HttpEntity<>(params,httpHeaders);
+        HttpEntity<MultiValueMap<String, String>> kakaoTokenRequest = new HttpEntity<>(params, httpHeaders);
 
         ResponseEntity<String> response = restTemplate.exchange(
                 KAKAO_TOKEN_URL,
@@ -71,13 +88,36 @@ public class Oauth2Util {
         return JsonParser.parseString(response.getBody()).getAsJsonObject().get("access_token").getAsString();
     }
 
+    public String getGoogleAccessToken(String authorizationCode) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", GOOGLE_CLIENT_ID);
+        params.add("client_secret", GOOGLE_CLIENT_SECRET);
+        params.add("redirect_uri", GOOGLE_REDIRECT_URL);
+        params.add("code", authorizationCode);
+
+        HttpEntity<MultiValueMap<String, String>> googleTokenRequest = new HttpEntity<>(params, httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GOOGLE_TOKEN_URL,
+                HttpMethod.POST,
+                googleTokenRequest,
+                String.class
+        );
+
+        return JsonParser.parseString(response.getBody()).getAsJsonObject().get("access_token").getAsString();
+    }
+
     public UserAuthResponse getKakaoUserInformation(String accessToken) {
         HttpHeaders httpHeaders = new HttpHeaders();
 
-        httpHeaders.add("Authorization", "Bearer "+ accessToken);
-        httpHeaders.add("Content-type","application/x-www-form-urlencoded;charset=utf-8");
+        httpHeaders.add("Authorization", "Bearer " + accessToken);
+        httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
-        HttpEntity<MultiValueMap<String,String >> kakaoProfileRequest= new HttpEntity<>(httpHeaders);
+        HttpEntity<MultiValueMap<String, String>> kakaoProfileRequest = new HttpEntity<>(httpHeaders);
 
         ResponseEntity<String> response = restTemplate.exchange(
                 KAKAO_USERINFO_URL,
@@ -100,5 +140,26 @@ public class Oauth2Util {
                 .build();
     }
 
+    public UserAuthResponse getGoogleUserInformation(String accessToken) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Authorization", "Bearer " + accessToken);
+        httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
+        HttpEntity<MultiValueMap<String, String>> googleProfileRequest = new HttpEntity<>(httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                GOOGLE_USERINFO_URL,
+                HttpMethod.GET,
+                googleProfileRequest,
+                String.class
+        );
+
+        Gson gson = new Gson();
+        JsonObject jsonObject = gson.fromJson(response.getBody(), JsonObject.class);
+
+        return UserAuthResponse.builder()
+                .name(jsonObject.get("name").getAsString())
+                .email(jsonObject.get("email").getAsString())
+                .build();
+    }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
@@ -29,9 +29,14 @@ public class Oauth2Util {
     @Value("${kakao.redirect_uri}")
     private String KAKAO_REDIRECT_URI;
 
-    private final String KAKAO_TOKEN_URL = "https://kauth.kakao.com/oauth/token";
-    private final String KAKAO_USERINFO_URL = "https://kapi.kakao.com/v2/user/me";
-    private final String KAKAO_AUTHORIZATION_URL = "https://kauth.kakao.com/oauth/authorize";
+    @Value("${kakao.token_url}")
+    private String KAKAO_TOKEN_URL;
+
+    @Value("${kakao.userinfo_url}")
+    private String KAKAO_USERINFO_URL;
+
+    @Value("${kakao.authorization_url}")
+    private String KAKAO_AUTHORIZATION_URL;
 
     // google
     @Value("${google.client.id}")
@@ -43,9 +48,14 @@ public class Oauth2Util {
     @Value("${google.client.secret}")
     private String GOOGLE_CLIENT_SECRET;
 
-    private final String GOOGLE_TOKEN_URL = "https://oauth2.googleapis.com/token";
-    private final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
-    private final String GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
+    @Value("${google.token_url}")
+    private String GOOGLE_TOKEN_URL;
+
+    @Value("${google.userinfo_url}")
+    private String GOOGLE_USERINFO_URL;
+
+    @Value("${google.authorization_url}")
+    private String GOOGLE_AUTHORIZATION_URL;
 
     // naver
     @Value("${naver.client.id}")
@@ -57,9 +67,14 @@ public class Oauth2Util {
     @Value("${naver.client.secret}")
     private String NAVER_CLIENT_SECRET;
 
-    private final String NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
-    private final String NAVER_USERINFO_URL = "https://openapi.naver.com/v1/nid/me";
-    private final String NAVER_AUTHORIZATION_URL = "https://nid.naver.com/oauth2.0/authorize";
+    @Value("${naver.token_url}")
+    private String NAVER_TOKEN_URL;
+
+    @Value("${naver.userinfo_url}")
+    private String NAVER_USERINFO_URL;
+
+    @Value("${naver.authorization_url}")
+    private String NAVER_AUTHORIZATION_URL;
 
 
     private static final RestTemplate restTemplate = new RestTemplate();

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/auth/Oauth2Util.java
@@ -15,8 +15,8 @@ import org.springframework.util.LinkedMultiValueMap;
 import org.springframework.util.MultiValueMap;
 import org.springframework.web.client.RestTemplate;
 
-import java.util.HashMap;
-import java.util.Map;
+import java.math.BigInteger;
+import java.security.SecureRandom;
 
 @Component
 @RequiredArgsConstructor
@@ -47,23 +47,44 @@ public class Oauth2Util {
     private final String GOOGLE_USERINFO_URL = "https://www.googleapis.com/oauth2/v2/userinfo";
     private final String GOOGLE_AUTHORIZATION_URL = "https://accounts.google.com/o/oauth2/v2/auth";
 
+    // naver
+    @Value("${naver.client.id}")
+    private String NAVER_CLIENT_ID;
+
+    @Value("${naver.redirect.uri}")
+    private String NAVER_REDIRECT_URL;
+
+    @Value("${naver.client.secret}")
+    private String NAVER_CLIENT_SECRET;
+
+    private final String NAVER_TOKEN_URL = "https://nid.naver.com/oauth2.0/token";
+    private final String NAVER_USERINFO_URL = "https://openapi.naver.com/v1/nid/me";
+    private final String NAVER_AUTHORIZATION_URL = "https://nid.naver.com/oauth2.0/authorize";
+
+
     private static final RestTemplate restTemplate = new RestTemplate();
 
     public String getKakaoRedirectUrl() {
-        String url = KAKAO_AUTHORIZATION_URL
+        return KAKAO_AUTHORIZATION_URL
                 + "?client_id=" + KAKAO_API_KEY
                 + "&redirect_uri=" + KAKAO_REDIRECT_URI
                 + "&response_type=code";
-        return url;
     }
 
     public String getGoogleRedirectUrl() {
-        String url = GOOGLE_AUTHORIZATION_URL
+        return GOOGLE_AUTHORIZATION_URL
                 + "?client_id=" + GOOGLE_CLIENT_ID
                 + "&redirect_uri=" + GOOGLE_REDIRECT_URL
-                + "&response_type=code&scope=email%20profile%20openid" +
-                "&access_type=offline";
-        return url;
+                + "&response_type=code&scope=email%20profile%20openid"
+                + "&access_type=offline";
+    }
+
+    public String getNaverRedirectUrl() {
+        return NAVER_AUTHORIZATION_URL
+                + "?client_id=" + NAVER_CLIENT_ID
+                + "&redirect_uri=" + NAVER_REDIRECT_URL
+                + "&response_type=code"
+                + "&state" + generateState();
     }
 
     public String getKakaoAccessToken(String authorizationCode) {
@@ -111,6 +132,29 @@ public class Oauth2Util {
         return JsonParser.parseString(response.getBody()).getAsJsonObject().get("access_token").getAsString();
     }
 
+    public String getNaverAccessToken(String authorizationCode, String state) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+        httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        MultiValueMap<String, String> params = new LinkedMultiValueMap<>();
+        params.add("grant_type", "authorization_code");
+        params.add("client_id", NAVER_CLIENT_ID);
+        params.add("client_secret", NAVER_CLIENT_SECRET);
+        params.add("code", authorizationCode);
+        params.add("state", state);
+
+        HttpEntity<MultiValueMap<String, String>> naverTokenRequest = new HttpEntity<>(params, httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                NAVER_TOKEN_URL,
+                HttpMethod.POST,
+                naverTokenRequest,
+                String.class
+        );
+
+        return JsonParser.parseString(response.getBody()).getAsJsonObject().get("access_token").getAsString();
+    }
+
     public UserAuthResponse getKakaoUserInformation(String accessToken) {
         HttpHeaders httpHeaders = new HttpHeaders();
 
@@ -125,23 +169,20 @@ public class Oauth2Util {
                 kakaoProfileRequest,
                 String.class
         );
-
-        // 토큰을 사용하여 사용자 정보 추출
-        JsonObject responseBody = JsonParser.parseString(response.getBody()).getAsJsonObject();
+        Gson gson = new Gson();
+        JsonObject responseBody = gson.fromJson(response.getBody(), JsonObject.class);
         JsonObject properties = responseBody.getAsJsonObject("properties");
         JsonObject kakaoAccount = responseBody.getAsJsonObject("kakao_account");
 
-        String nickname = properties.getAsJsonObject().get("nickname").getAsString();
-        String email = kakaoAccount.getAsJsonObject().get("email").getAsString();
-
         return UserAuthResponse.builder()
-                .name(nickname)
-                .email(email)
+                .name(properties.get("nickname").getAsString())
+                .email(kakaoAccount.get("email").getAsString())
                 .build();
     }
 
     public UserAuthResponse getGoogleUserInformation(String accessToken) {
         HttpHeaders httpHeaders = new HttpHeaders();
+
         httpHeaders.add("Authorization", "Bearer " + accessToken);
         httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
 
@@ -155,11 +196,41 @@ public class Oauth2Util {
         );
 
         Gson gson = new Gson();
-        JsonObject jsonObject = gson.fromJson(response.getBody(), JsonObject.class);
+        JsonObject responseBody = gson.fromJson(response.getBody(), JsonObject.class);
 
         return UserAuthResponse.builder()
-                .name(jsonObject.get("name").getAsString())
-                .email(jsonObject.get("email").getAsString())
+                .name(responseBody.get("name").getAsString())
+                .email(responseBody.get("email").getAsString())
                 .build();
+    }
+
+    public UserAuthResponse getNaverUserInformation(String accessToken) {
+        HttpHeaders httpHeaders = new HttpHeaders();
+
+        httpHeaders.add("Authorization", "Bearer " + accessToken);
+        httpHeaders.add("Content-type", "application/x-www-form-urlencoded;charset=utf-8");
+
+        HttpEntity<MultiValueMap<String, String>> naverProfileRequest = new HttpEntity<>(httpHeaders);
+
+        ResponseEntity<String> response = restTemplate.exchange(
+                NAVER_USERINFO_URL,
+                HttpMethod.GET,
+                naverProfileRequest,
+                String.class
+        );
+
+        Gson gson = new Gson();
+        JsonObject responseBody = gson.fromJson(response.getBody(), JsonObject.class);
+        JsonObject responseDetails = responseBody.getAsJsonObject("response");
+
+        return UserAuthResponse.builder()
+                .name(responseDetails.get("name").getAsString())
+                .email(responseDetails.get("email").getAsString())
+                .build();
+    }
+
+    private String generateState() {
+        SecureRandom random = new SecureRandom();
+        return new BigInteger(130, random).toString(32);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
@@ -47,6 +47,7 @@ public class SecurityConfig {
                         .accessDeniedHandler(accessDeniedHandler))
                 .authorizeHttpRequests(authorize -> authorize
                         .requestMatchers(AUTH_WHITELIST).permitAll()
+                        .requestMatchers("/auth/**").permitAll()
                         .anyRequest().authenticated());
 
         return http.build();

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
@@ -36,7 +36,7 @@ public class UserController {
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
 
-        return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
+        return new ResponseEntity<>("유저가 로그인되었습니다.", headers, HttpStatus.OK);
     }
 
     @GetMapping("/auth/kakao")
@@ -51,25 +51,36 @@ public class UserController {
         return new ResponseEntity<>(url, HttpStatus.OK);
     }
 
+    @GetMapping("/auth/naver")
+    public ResponseEntity getNaverRedirectUrl() {
+        String url = userService.getRedirectUrl(LoginType.NAVER);
+        return new ResponseEntity<>(url, HttpStatus.OK);
+    }
+
     @GetMapping("/auth/kakao/callback")
     public ResponseEntity<String> kakaoCallback(@RequestParam("code") String code) {
-        // accesstoken 받기
-        String accessToken = userService.getAccessToken(code, LoginType.KAKAO);
-
+        String accessToken = userService.getAccessToken(code, LoginType.KAKAO, null);
         String token = userService.authLogin(accessToken, LoginType.KAKAO);
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
-        return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
+        return new ResponseEntity<>("유저가 로그인되었습니다.", headers, HttpStatus.OK);
     }
 
     @GetMapping("/auth/google/callback")
     public ResponseEntity<String> googleCallback(@RequestParam("code") String code) {
-        // accesstoken 받기
-        String accessToken = userService.getAccessToken(code, LoginType.GOOGLE);
-
+        String accessToken = userService.getAccessToken(code, LoginType.GOOGLE, null);
         String token = userService.authLogin(accessToken, LoginType.GOOGLE);
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
-        return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
+        return new ResponseEntity<>("유저가 로그인되었습니다.", headers, HttpStatus.OK);
+    }
+
+    @GetMapping("/auth/naver/callback")
+    public ResponseEntity<String> naverCallback(@RequestParam("code") String code, @RequestParam("state") String state) {
+        String accessToken = userService.getAccessToken(code, LoginType.NAVER, state);
+        String token = userService.authLogin(accessToken, LoginType.NAVER);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        return new ResponseEntity<>("유저가 로그인되었습니다.", headers, HttpStatus.OK);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserController.java
@@ -42,7 +42,12 @@ public class UserController {
     @GetMapping("/auth/kakao")
     public ResponseEntity getKakaoRedirectUrl() {
         String url = userService.getRedirectUrl(LoginType.KAKAO);
-//        map.put("url", userService.getRedirectUrl(LoginType.KAKAO));
+        return new ResponseEntity<>(url, HttpStatus.OK);
+    }
+
+    @GetMapping("/auth/google")
+    public ResponseEntity getGoogleRedirectUrl() {
+        String url = userService.getRedirectUrl(LoginType.GOOGLE);
         return new ResponseEntity<>(url, HttpStatus.OK);
     }
 
@@ -50,8 +55,19 @@ public class UserController {
     public ResponseEntity<String> kakaoCallback(@RequestParam("code") String code) {
         // accesstoken 받기
         String accessToken = userService.getAccessToken(code, LoginType.KAKAO);
-        //
+
         String token = userService.authLogin(accessToken, LoginType.KAKAO);
+        HttpHeaders headers = new HttpHeaders();
+        headers.set("Authorization", "Bearer " + token);
+        return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);
+    }
+
+    @GetMapping("/auth/google/callback")
+    public ResponseEntity<String> googleCallback(@RequestParam("code") String code) {
+        // accesstoken 받기
+        String accessToken = userService.getAccessToken(code, LoginType.GOOGLE);
+
+        String token = userService.authLogin(accessToken, LoginType.GOOGLE);
         HttpHeaders headers = new HttpHeaders();
         headers.set("Authorization", "Bearer " + token);
         return new ResponseEntity<>("유저가 로그인되었습니다.",headers, HttpStatus.OK);

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserService.java
@@ -62,9 +62,9 @@ public class UserService {
             case KAKAO -> {
                 return oauth2Util.getKakaoRedirectUrl();
             }
-//            case GOOGLE -> {
-//                return oauth2Util.getGoogleRedirectUrl();
-//            }
+            case GOOGLE -> {
+                return oauth2Util.getGoogleRedirectUrl();
+            }
 //            case NAVER -> {
 //                return oauth2Util.getAppleRedirectUrl();
 //            }
@@ -78,9 +78,9 @@ public class UserService {
             case KAKAO -> {
                 accessToken = oauth2Util.getKakaoAccessToken(authorizationCode);
             }
-//            case GOOGLE -> {
-//                accessToken = oauth2Util.getGoogleAccessToken(authorizationCode);
-//            }
+            case GOOGLE -> {
+                accessToken = oauth2Util.getGoogleAccessToken(authorizationCode);
+            }
 //            case NAVER -> {
 //                accessToken = authorizationCode;
 //            }
@@ -94,9 +94,9 @@ public class UserService {
             case KAKAO -> {
                 userAuthResponse = oauth2Util.getKakaoUserInformation(accessToken);
             }
-//            case GOOGLE -> {
-//                userCreateResponse = oauth2Util.getGoogleUserInformation(accessToken);
-//            }
+            case GOOGLE -> {
+                userAuthResponse = oauth2Util.getGoogleUserInformation(accessToken);
+            }
 //            case NAVER -> {
 //                userCreateResponse = oauth2Util.getNAVERUserInformation(accessToken);
 //            }
@@ -109,7 +109,7 @@ public class UserService {
                     .email(userAuthResponse.email())
                     .name(userAuthResponse.name())
                     .userRole("USER")
-                    .loginType("KAKAO")
+                    .loginType(loginType.toString())
                     .build();
 
             user = userRepository.save(createdUser);

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/UserService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/UserService.java
@@ -65,14 +65,14 @@ public class UserService {
             case GOOGLE -> {
                 return oauth2Util.getGoogleRedirectUrl();
             }
-//            case NAVER -> {
-//                return oauth2Util.getAppleRedirectUrl();
-//            }
+            case NAVER -> {
+                return oauth2Util.getNaverRedirectUrl();
+            }
         }
         return null;
     }
 
-    public String getAccessToken(String authorizationCode, LoginType loginType){
+    public String getAccessToken(String authorizationCode, LoginType loginType, String state){
         String accessToken = null;
         switch (loginType) {
             case KAKAO -> {
@@ -81,9 +81,9 @@ public class UserService {
             case GOOGLE -> {
                 accessToken = oauth2Util.getGoogleAccessToken(authorizationCode);
             }
-//            case NAVER -> {
-//                accessToken = authorizationCode;
-//            }
+            case NAVER -> {
+                accessToken = oauth2Util.getNaverAccessToken(authorizationCode, state);
+            }
         }
         return accessToken;
     }
@@ -97,9 +97,9 @@ public class UserService {
             case GOOGLE -> {
                 userAuthResponse = oauth2Util.getGoogleUserInformation(accessToken);
             }
-//            case NAVER -> {
-//                userCreateResponse = oauth2Util.getNAVERUserInformation(accessToken);
-//            }
+            case NAVER -> {
+                userAuthResponse = oauth2Util.getNaverUserInformation(accessToken);
+            }
         }
 
         Optional<User> findUser = userRepository.findByEmail(userAuthResponse.email());


### PR DESCRIPTION
## 🔎 작업 내용

- naver, google 로그인 추가

- 가입 되지 않은 회원이면 db 저장하기

- 가입된 회원이면 access 토큰 발급 후 로그인

- sso 관련 모든 key secret으로 설정


<br/>

## 🔧 앞으로의 과제

- 채용 정보 시각화


  <br/>

## ➕ 이슈 링크

<br/>