### PR TITLE
[#55] fix: 크롤링된 채용공고를 DB에 저장 /  [#33] feat: 방문자 수 업데이트 및 불러오기

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCount.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCount.java
@@ -29,4 +29,8 @@ public class VisitorCount {
     public VisitorCount() {
 
     }
+
+    public void updateVisitorCount() {
+        this.visitCount++;
+    }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountRepository.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountRepository.java
@@ -8,7 +8,7 @@ import java.util.Optional;
 
 public interface VisitorCountRepository extends JpaRepository<VisitorCount, Long> {
 
-    VisitorCount findByVisitDate(LocalDate date);
+    Optional<VisitorCount> findByVisitDate(LocalDate date);
 
     @Query("SELECT sum(v.visitCount) FROM VisitorCount v " +
             "WHERE v.visitDate BETWEEN :start AND :end")

--- a/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountResponse.java
@@ -5,13 +5,11 @@ import lombok.Builder;
 import java.time.LocalDate;
 
 public record VisitorCountResponse(
-        Long visitorCount,
-        LocalDate visitDate
+        Long visitorCount
 ) {
 
     @Builder
-    public VisitorCountResponse(Long visitorCount, LocalDate visitDate) {
+    public VisitorCountResponse(Long visitorCount) {
         this.visitorCount = visitorCount;
-        this.visitDate = visitDate;
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/api/visitorcount/VisitorCountService.java
@@ -5,6 +5,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.time.LocalDate;
+import java.util.Optional;
 
 @Slf4j
 @Service
@@ -51,13 +52,25 @@ public class VisitorCountService {
 
     private void initTodayCount() {
         LocalDate today = LocalDate.now();
-        VisitorCount visitorCount = visitorCountRepository.findByVisitDate(today);
-        if (visitorCount == null) {
+        Optional<VisitorCount> visitorCount = visitorCountRepository.findByVisitDate(today);
+        if (visitorCount.isEmpty()) {
             visitorCountRepository.save(VisitorCount.builder()
                     .visitCount(0L)
                     .visitDate(today)
                     .build()
             );
         }
+    }
+
+    public VisitorCountResponse updateVisitorCount() {
+        LocalDate today = LocalDate.now();
+        VisitorCount visitorCount = visitorCountRepository.findByVisitDate(today)
+                .orElseThrow(() -> new IllegalArgumentException("오늘자 방문자 수가 없습니다."));
+
+        visitorCount.updateVisitorCount();
+        visitorCountRepository.save(visitorCount);
+        return VisitorCountResponse.builder()
+                .visitorCount(visitorCount.getVisitCount())
+                .build();
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
@@ -15,17 +15,19 @@ public class CompanyRecruitmentCrawling {
 
     private final CompanyCrawling companyCrawling;
     private final RecruitmentCrawling recruitmentCrawling;
+    private final RecruitmentCrawlingService recruitmentCrawlingService;
 
-    public CompanyRecruitmentCrawling(CompanyCrawling companyCrawling, RecruitmentCrawling recruitmentCrawling) {
+    public CompanyRecruitmentCrawling(CompanyCrawling companyCrawling, RecruitmentCrawling recruitmentCrawling, RecruitmentCrawlingService recruitmentCrawlingService) {
         this.companyCrawling = companyCrawling;
         this.recruitmentCrawling = recruitmentCrawling;
+        this.recruitmentCrawlingService = recruitmentCrawlingService;
     }
 
-    //@Scheduled(fixedRate = 60000)
+    @Scheduled(cron = "0 0 0 * * *")
     public void companyAndRecruitmentCrawling() {
         CrawledCompanyDto crawledCompanyDto = companyCrawling.getCompanyThreePage();
         log.info(crawledCompanyDto.toString());
-        recruitmentCrawling.crawlingJUMPIT(crawledCompanyDto.getEnterpriseNames());
+        List<CrawledRecruitmentDto> list = recruitmentCrawling.crawlingJUMPIT(crawledCompanyDto.getEnterpriseNames());
+        recruitmentCrawlingService.createRecruitment(list);
     }
-
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawlingService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/RecruitmentCrawlingService.java
@@ -1,11 +1,17 @@
 package com.teamdevroute.devroute.crawling;
 
+import com.teamdevroute.devroute.company.Company;
+import com.teamdevroute.devroute.company.CompanyRepository;
 import com.teamdevroute.devroute.crawling.dto.CrawledRecruitmentDto;
+import com.teamdevroute.devroute.global.exception.CompanyNotFoundException;
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.enums.Source;
 import com.teamdevroute.devroute.recruitment.repository.RecruitmentRepository;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Service
@@ -14,10 +20,15 @@ import java.util.List;
 public class RecruitmentCrawlingService {
 
     private RecruitmentRepository recruitmentRepository;
+    private CompanyRepository companyRepository;
 
     // TODO 채용공고 엔티티 수정 후 구현
     public void createRecruitment(List<CrawledRecruitmentDto> crawledRecruitmentDtoList) {
-
-
+        for(CrawledRecruitmentDto dto : crawledRecruitmentDtoList) {
+            Company company = companyRepository.findByName(dto.getCompanyName())
+                            .orElseThrow(CompanyNotFoundException::new);
+            Source source = Source.JUMPIT;
+            recruitmentRepository.save(dto.toEntity(company, source));
+        }
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledRecruitmentDto.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/dto/CrawledRecruitmentDto.java
@@ -1,5 +1,8 @@
 package com.teamdevroute.devroute.crawling.dto;
 
+import com.teamdevroute.devroute.company.Company;
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.enums.Source;
 import lombok.*;
 
 import java.util.List;
@@ -24,5 +27,16 @@ public class CrawledRecruitmentDto {
         this.techList = techList;
         this.area = area;
         this.career = career;
+    }
+
+
+//    List<String> techStacks, String annual, LocalDateTime dueDate, String url, Company company, Source source
+    public Recruitment toEntity(Company company, Source source) {
+        return Recruitment.builder()
+                .techStacks(techList)
+                .annual(career)
+                .company(company)
+                .source(source)
+                .build();
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/exception/CompanyNotFoundException.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/exception/CompanyNotFoundException.java
@@ -1,0 +1,6 @@
+package com.teamdevroute.devroute.global.exception;
+
+public class CompanyNotFoundException extends RuntimeException {
+    public CompanyNotFoundException() {
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/enums/Source.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/enums/Source.java
@@ -2,5 +2,6 @@ package com.teamdevroute.devroute.recruitment.enums;
 
 public enum Source {
     SARAMIN,
-    JOB_PLANET
+    JOB_PLANET,
+    JUMPIT
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/user/domain/User.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/user/domain/User.java
@@ -8,6 +8,7 @@ import jakarta.validation.constraints.NotNull;
 import jakarta.validation.constraints.Size;
 import lombok.*;
 import org.hibernate.annotations.ColumnDefault;
+import org.springframework.boot.context.properties.bind.DefaultValue;
 import org.springframework.data.annotation.LastModifiedDate;
 
 import java.time.LocalDateTime;
@@ -43,6 +44,7 @@ public class User extends BaseTimeEntity {
 
     @Column(name = "development_field")
     @Enumerated(EnumType.STRING)
+    @ColumnDefault("'NONE'")
     private DevelopField developField;
 
     @Column

--- a/dev-route/src/test/java/com/teamdevroute/devroute/user/UserFixture.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/user/UserFixture.java
@@ -1,6 +1,7 @@
 package com.teamdevroute.devroute.user;
 
 import com.teamdevroute.devroute.user.domain.User;
+import com.teamdevroute.devroute.user.enums.DevelopField;
 
 public class UserFixture {
 
@@ -9,7 +10,7 @@ public class UserFixture {
                 .email("email")
                 .password("password")
                 .name(name)
-                .developField("AI")
+                .developField(DevelopField.AI)
                 .build();
     }
 }

--- a/dev-route/src/test/java/com/teamdevroute/devroute/visitorcount/VisitorCountServiceTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/visitorcount/VisitorCountServiceTest.java
@@ -1,0 +1,30 @@
+package com.teamdevroute.devroute.visitorcount;
+
+import com.teamdevroute.devroute.api.visitorcount.VisitorCountResponse;
+import com.teamdevroute.devroute.api.visitorcount.VisitorCountService;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+@SpringBootTest
+public class VisitorCountServiceTest {
+
+    @Autowired
+    private VisitorCountService visitorCountService;
+
+    @Test
+    void update_visitor_count() {
+        assertThatThrownBy(() -> visitorCountService.updateVisitorCount())
+                .isInstanceOf(IllegalArgumentException.class)
+                .hasMessage("오늘자 방문자 수가 없습니다.");
+    }
+
+    @Test
+    void create_visitor_count() {
+        VisitorCountResponse response = visitorCountService.getVisitorCount(0);
+        assertThat(response.visitorCount()).isEqualTo(0L);
+    }
+}


### PR DESCRIPTION
## 🔎 작업 내용

- 기존 크롤링된 채용공고를 DB에 저장하는 로직 추가
    - 회사의 이름을 바탕으로 저장된 회사를 검색
- 불러오기의 경우, (0, 오늘), (1, 일주일간), (2, 월간) 타입을 쿼리 파라미터로 받아서 처리


<br/>

## 🔧 앞으로의 과제

- 채용공고의 URL 및 마감일자 받아오기

  <br/>

## ➕ 이슈 링크

<br/>