### PR TITLE
[#70]feat: 기업 소개 및 해당 기업 공고글 조회 / [#71]fix: #70번 이슈 해결 

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/CompanyControllerAdvice.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/CompanyControllerAdvice.java
@@ -1,0 +1,15 @@
+package com.teamdevroute.devroute.company;
+
+import com.teamdevroute.devroute.global.exception.CompanyNotFoundException;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.ControllerAdvice;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+
+@ControllerAdvice
+public class CompanyControllerAdvice {
+
+    @ExceptionHandler(CompanyNotFoundException.class)
+    public ResponseEntity handleCompanyNotFoundExceptionException(CompanyNotFoundException e) {
+        return ResponseEntity.badRequest().body("기업을 찾을 수 없습니다.");
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/controller/CompanyController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/controller/CompanyController.java
@@ -1,5 +1,6 @@
 package com.teamdevroute.devroute.company.controller;
 
+import com.teamdevroute.devroute.company.dto.CompanyDetailResponse;
 import com.teamdevroute.devroute.company.dto.CompanyResponse;
 import com.teamdevroute.devroute.company.service.CompanyService;
 import lombok.AllArgsConstructor;
@@ -7,6 +8,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
 import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.PathVariable;
 
 import java.util.List;
 
@@ -20,6 +22,12 @@ public class CompanyController {
     @GetMapping("/recruit/enterprise")
     public ResponseEntity getAllCompanies() {
         List<CompanyResponse> response = companyService.findAll();
+        return ResponseEntity.ok(response);
+    }
+
+    @GetMapping("/recruit/company/{companyId}")
+    public ResponseEntity getCompanyDetail(@PathVariable("companyId") long companyId) {
+        CompanyDetailResponse response = companyService.findCompanyDetail(companyId);
         return ResponseEntity.ok(response);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailRecruitResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailRecruitResponse.java
@@ -1,0 +1,33 @@
+package com.teamdevroute.devroute.company.dto;
+
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.user.enums.DevelopField;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class CompanyDetailRecruitResponse {
+    private DevelopField developField;
+    private List<String> techStacks;
+    private LocalDateTime dueDate;
+
+    @Builder
+    public CompanyDetailRecruitResponse(DevelopField developField, List<String> techStacks, LocalDateTime dueDate) {
+        this.developField = developField;
+        this.techStacks = techStacks;
+        this.dueDate = dueDate;
+    }
+
+    public static CompanyDetailRecruitResponse from(Recruitment recruitment) {
+        return CompanyDetailRecruitResponse.builder()
+                .developField(recruitment.getDevelopField())
+                .techStacks(recruitment.getTechStacks())
+                .dueDate(recruitment.getDueDate())
+                .build();
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailResponse.java
@@ -1,0 +1,41 @@
+package com.teamdevroute.devroute.company.dto;
+
+import com.teamdevroute.devroute.company.domain.Company;
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.util.List;
+
+@Getter
+@Setter
+public class CompanyDetailResponse {
+    private String name;
+    private String info;
+    private Double grade;
+    private String averageSalary;
+    private List<Recruitment> recruitments;
+
+    @Builder
+    public CompanyDetailResponse(String name, String info, Double grade, String averageSalary, List<Recruitment> recruitments) {
+        this.name = name;
+        this.info = info;
+        this.grade = grade;
+        this.averageSalary = averageSalary;
+        this.recruitments = recruitments;
+    }
+
+    public static CompanyDetailResponse from(
+            Company company,
+            List<Recruitment> recruitments
+    ) {
+        return CompanyDetailResponse.builder()
+                .name(company.getName())
+                .info(company.getInfo())
+                .grade(company.getGrade())
+                .averageSalary(company.getAverageSalary())
+                .recruitments(recruitments)
+                .build();
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyDetailResponse.java
@@ -15,10 +15,10 @@ public class CompanyDetailResponse {
     private String info;
     private Double grade;
     private String averageSalary;
-    private List<Recruitment> recruitments;
+    private List<CompanyDetailRecruitResponse> recruitments;
 
     @Builder
-    public CompanyDetailResponse(String name, String info, Double grade, String averageSalary, List<Recruitment> recruitments) {
+    public CompanyDetailResponse(String name, String info, Double grade, String averageSalary, List<CompanyDetailRecruitResponse> recruitments) {
         this.name = name;
         this.info = info;
         this.grade = grade;
@@ -28,7 +28,7 @@ public class CompanyDetailResponse {
 
     public static CompanyDetailResponse from(
             Company company,
-            List<Recruitment> recruitments
+            List<CompanyDetailRecruitResponse> recruitments
     ) {
         return CompanyDetailResponse.builder()
                 .name(company.getName())

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/service/CompanyService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/service/CompanyService.java
@@ -1,6 +1,7 @@
 package com.teamdevroute.devroute.company.service;
 
 import com.teamdevroute.devroute.company.domain.Company;
+import com.teamdevroute.devroute.company.dto.CompanyDetailRecruitResponse;
 import com.teamdevroute.devroute.company.dto.CompanyDetailResponse;
 import com.teamdevroute.devroute.company.repository.CompanyRepository;
 import com.teamdevroute.devroute.company.dto.CompanyResponse;
@@ -35,6 +36,12 @@ public class CompanyService {
         Company company = companyRepository.findById(id)
                 .orElseThrow(CompanyNotFoundException::new);
         List<Recruitment> recruitments = recruitmentRepository.findByCompany(company);
-        return CompanyDetailResponse.from(company, recruitments);
+
+        List<CompanyDetailRecruitResponse> response = null;
+        if(!recruitments.isEmpty()) {
+            response= recruitments.stream().map(CompanyDetailRecruitResponse::from).toList();
+        }
+
+        return CompanyDetailResponse.from(company, response);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/service/CompanyService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/service/CompanyService.java
@@ -1,15 +1,17 @@
 package com.teamdevroute.devroute.company.service;
 
 import com.teamdevroute.devroute.company.domain.Company;
+import com.teamdevroute.devroute.company.dto.CompanyDetailResponse;
 import com.teamdevroute.devroute.company.repository.CompanyRepository;
 import com.teamdevroute.devroute.company.dto.CompanyResponse;
 import com.teamdevroute.devroute.global.exception.CompanyNotFoundException;
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.repository.RecruitmentRepository;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Slf4j
 @AllArgsConstructor
@@ -17,6 +19,7 @@ import java.util.stream.Collectors;
 public class CompanyService {
 
     private CompanyRepository companyRepository;
+    private RecruitmentRepository recruitmentRepository;
 
     public List<CompanyResponse> findAll() {
         List<Company> companyList = companyRepository.findAll();
@@ -26,5 +29,12 @@ public class CompanyService {
     public Company findById(Long id) {
         return companyRepository.findById(id)
                 .orElseThrow(CompanyNotFoundException::new);
+    }
+
+    public CompanyDetailResponse findCompanyDetail(Long id) {
+        Company company = companyRepository.findById(id)
+                .orElseThrow(CompanyNotFoundException::new);
+        List<Recruitment> recruitments = recruitmentRepository.findByCompany(company);
+        return CompanyDetailResponse.from(company, recruitments);
     }
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/repository/RecruitmentRepository.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/repository/RecruitmentRepository.java
@@ -1,5 +1,6 @@
 package com.teamdevroute.devroute.recruitment.repository;
 
+import com.teamdevroute.devroute.company.domain.Company;
 import com.teamdevroute.devroute.recruitment.domain.Recruitment;
 import com.teamdevroute.devroute.user.enums.DevelopField;
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -18,4 +19,6 @@ public interface RecruitmentRepository extends JpaRepository<Recruitment, Long> 
 
     @Query("SELECT r FROM Recruitment r WHERE r.developField = :developField AND r.source = 'SARAMIN'")
     List<Recruitment> findByDevelopFieldAndSource(@Param("developField") DevelopField developField);
+
+    List<Recruitment> findByCompany(Company company);
 }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentService.java
@@ -1,5 +1,8 @@
 package com.teamdevroute.devroute.recruitment.service;
 
+import com.teamdevroute.devroute.company.domain.Company;
+import com.teamdevroute.devroute.company.repository.CompanyRepository;
+import com.teamdevroute.devroute.global.exception.CompanyNotFoundException;
 import com.teamdevroute.devroute.recruitment.domain.Recruitment;
 import com.teamdevroute.devroute.recruitment.dto.TechStackFrequencyDto;
 import com.teamdevroute.devroute.recruitment.repository.RecruitmentRepository;
@@ -19,6 +22,7 @@ public class RecruitmentService {
 
     private final RecruitmentRepository recruitmentRepository;
     private final TechnologyStackCategory technologyStackCategory;
+    private final CompanyRepository companyRepository;
 
     public List<Recruitment> findByType(String type) {
         DevelopField developField = DevelopField.toEnum(type);


### PR DESCRIPTION
## 🔎 작업 내용
### ✨feat
- `company_id`를 이용하여 해당 기업의 상세 정보 조회
- 전달하는 정보: 이름, 소개말, 평점, 평균연봉, 모든 채용공고들
- 
### 🔥fix
- `Recruitment`와 `Company`의 **양방향 매핑**으로 인해 Company에서 Recuritment 반환 시, Recruitment에서 Company 반환이 무한이 반복되는 이슈가 발생
- 이를 해결하기 위해 Company에서 Recuritment 반환 대신, `별도의 dto`를 이용하여 양방향 연관관계는 반환하지 않도록 수정

<br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크


<br/>