### PR TITLE
[#73]fix: 북마크 등록 API의 유저 정보 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkController.java
@@ -15,11 +15,9 @@ public class BookmarkController {
 
     @PostMapping("/bookmark")
     public ResponseEntity addBookmark(
-            @RequestParam(name = "userId") String id,
             @RequestBody BookmarkUpdateRequest request
     ) {
-
-        bookmarkService.updateBookmark(Long.parseLong(id), request);
+        bookmarkService.updateBookmark(request);
         return ResponseEntity.ok("북마크가 추가되었습니다.");
     }
 

--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkService.java
@@ -29,8 +29,8 @@ public class BookmarkService {
     private final VideoService videoService;
     private final TechnologyStackService technologyStackService;
 
-    public void updateBookmark(Long userId, BookmarkUpdateRequest request) {
-        User user = userService.findByUserId(userId);
+    public void updateBookmark(BookmarkUpdateRequest request) {
+        User user = userService.findByUserId(request.getUserId());
         log.info("updateBookmark() : {}", user.getEmail());
 
         if(user.getBookmark() == null) {

--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkUpdateRequest.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkUpdateRequest.java
@@ -7,6 +7,7 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class BookmarkUpdateRequest {
+    private Long userId;
     private Long id;
     private String type;
     public BookmarkUpdateRequest() {

--- a/dev-route/src/test/java/com/teamdevroute/devroute/bookmark/BookmarkServiceTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/bookmark/BookmarkServiceTest.java
@@ -12,7 +12,7 @@ public class BookmarkServiceTest {
 
     @Test
     void update_bookmark() {
-        BookmarkUpdateRequest request = new BookmarkUpdateRequest(1L, "company");
-        bookmarkService.updateBookmark(1L, request);
+        BookmarkUpdateRequest request = new BookmarkUpdateRequest(1L, 1L, "company");
+        bookmarkService.updateBookmark(request);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 쿼리파라미터로 유저의 id를 입력받는 대신, body로 유저의 id를 받도록 수정
- Post의 경우, 쿼리 파라미터를 사용하기 보단 안전한 body를 이용

<br/>

## 🔧 앞으로의 과제

- 인프라 구축 시작

  <br/>

## ➕ 이슈 링크

<br/>