### PR TITLE
[#74]fix: 직종별 채용공고 검색 시, Recuritment와 Company가 서로를 의존하면 무한히 반복되는 현상

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/controller/RecruitmentController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/controller/RecruitmentController.java
@@ -1,6 +1,7 @@
 package com.teamdevroute.devroute.recruitment.controller;
 
 import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.dto.RecruitmentFindResponse;
 import com.teamdevroute.devroute.recruitment.service.RecruitmentService;
 import com.teamdevroute.devroute.recruitment.service.RecruitmentUpdateService;
 import com.teamdevroute.devroute.user.enums.DevelopField;
@@ -27,7 +28,7 @@ public class RecruitmentController {
     public ResponseEntity searchRecruitmentByField(
             @RequestParam String type
     ) {
-        List<Recruitment> response = recruitmentService.findByType(type);
+        List<RecruitmentFindResponse> response = recruitmentService.findByType(type);
         return ResponseEntity.ok(response);
     }
 

--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/dto/RecruitmentFindResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/dto/RecruitmentFindResponse.java
@@ -1,0 +1,37 @@
+package com.teamdevroute.devroute.recruitment.dto;
+
+import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.user.enums.DevelopField;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.Setter;
+
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.util.List;
+
+@Getter
+@Setter
+public class RecruitmentFindResponse {
+    private String companyName;
+    private DevelopField developField;
+    private List<String> techStack;
+    private LocalDateTime dueDate;
+
+    @Builder
+    public RecruitmentFindResponse(String companyName, DevelopField developField, List<String> techStack, LocalDateTime dueDate) {
+        this.companyName = companyName;
+        this.developField = developField;
+        this.techStack = techStack;
+        this.dueDate = dueDate;
+    }
+
+    public static RecruitmentFindResponse from(Recruitment recruitment) {
+        return RecruitmentFindResponse.builder()
+                .companyName(recruitment.getCompany().getName())
+                .developField(recruitment.getDevelopField())
+                .techStack(recruitment.getTechStacks())
+                .dueDate(recruitment.getDueDate())
+                .build();
+    }
+}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentService.java
@@ -4,6 +4,7 @@ import com.teamdevroute.devroute.company.domain.Company;
 import com.teamdevroute.devroute.company.repository.CompanyRepository;
 import com.teamdevroute.devroute.global.exception.CompanyNotFoundException;
 import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.dto.RecruitmentFindResponse;
 import com.teamdevroute.devroute.recruitment.dto.TechStackFrequencyDto;
 import com.teamdevroute.devroute.recruitment.repository.RecruitmentRepository;
 import com.teamdevroute.devroute.recruitment.utils.TechnologyStackCategory;
@@ -24,13 +25,14 @@ public class RecruitmentService {
     private final TechnologyStackCategory technologyStackCategory;
     private final CompanyRepository companyRepository;
 
-    public List<Recruitment> findByType(String type) {
+    public List<RecruitmentFindResponse> findByType(String type) {
         DevelopField developField = DevelopField.toEnum(type);
         log.info("RecruitmentService - findByType(): type=" + developField);
         if(developField.equals(DevelopField.NONE)){
             throw new IllegalArgumentException("개발직군에 이상이 있습니다. 확인해주세요.");
         }
-        return recruitmentRepository.findByDevelopField(developField);
+        List<Recruitment> result = recruitmentRepository.findByDevelopField(developField);
+        return result.stream().map(RecruitmentFindResponse::from).toList();
     }
 
     public List<TechStackFrequencyDto> filterTechStackRate(DevelopField type) {

--- a/dev-route/src/test/java/com/teamdevroute/devroute/recruitment/RecruitmentServiceTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/recruitment/RecruitmentServiceTest.java
@@ -1,6 +1,7 @@
 package com.teamdevroute.devroute.recruitment;
 
 import com.teamdevroute.devroute.recruitment.domain.Recruitment;
+import com.teamdevroute.devroute.recruitment.dto.RecruitmentFindResponse;
 import com.teamdevroute.devroute.recruitment.service.RecruitmentService;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -20,7 +21,7 @@ public class RecruitmentServiceTest {
 
     @Test
     void search_develop_recruit() {
-        List<Recruitment> res = recruitmentService.findByType("backend");
+        List<RecruitmentFindResponse> res = recruitmentService.findByType("backend");
         assertThat(res.size()).isEqualTo(1);
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- Recruitment 안에 있는 Company가 호출되고, Company 안에 있는 Recruitment가 호출
- 위 현상이 무한히 반복되는 문제 발생

- API 콜에서 Recruitment를 바로 반환하는 것이 아닌 별도의 DTO인 RecruitmentFindResponse를 반환하도록 수정

<br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>