### PR TITLE
[#79] fix: 북마크의 유저id를 받는 대신 @AuthenticationPrincipal 이용하도록 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkController.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkController.java
@@ -2,6 +2,7 @@ package com.teamdevroute.devroute.bookmark;
 
 import com.teamdevroute.devroute.global.auth.LoginUserInfo;
 import com.teamdevroute.devroute.user.domain.CustomUserDetails;
+import com.teamdevroute.devroute.user.domain.User;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.ResponseEntity;
@@ -20,18 +21,20 @@ public class BookmarkController {
 
     @PostMapping("/bookmark/add")
     public ResponseEntity addBookmark(
+            @AuthenticationPrincipal CustomUserDetails userDetails,
             @RequestBody BookmarkUpdateRequest request
     ) {
-        bookmarkService.updateBookmark(request);
+        LoginUserInfo user = userDetails.getUser();
+        bookmarkService.updateBookmark(request, user.getId());
         return ResponseEntity.ok("북마크가 추가되었습니다.");
     }
 
     @PostMapping("/bookmark/get")
     public ResponseEntity getBookmark(
-            @RequestBody BookmarkFindRequest request
+            @AuthenticationPrincipal CustomUserDetails userDetails
             ) {
-
-        Bookmark bookmark = bookmarkService.findBookmarkByType(request.getUserId());
+        LoginUserInfo user = userDetails.getUser();
+        Bookmark bookmark = bookmarkService.findBookmarkByType(user.getId());
         if(bookmark == null) {
             return ResponseEntity.noContent().build();
         }

--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkService.java
@@ -24,8 +24,8 @@ public class BookmarkService {
     private final VideoService videoService;
     private final UserRepository userRepository;
 
-    public void updateBookmark(BookmarkUpdateRequest request) {
-        User user = userRepository.findById(request.getUserId()).orElseThrow(UserNotFoundException::new);
+    public void updateBookmark(BookmarkUpdateRequest request, Long userId) {
+        User user = userRepository.findById(userId).orElseThrow(UserNotFoundException::new);
         Bookmark bookmark = user.getBookmark();
         String type = request.getType();
 

--- a/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkUpdateRequest.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/bookmark/BookmarkUpdateRequest.java
@@ -7,7 +7,6 @@ import lombok.NoArgsConstructor;
 @AllArgsConstructor
 @Getter
 public class BookmarkUpdateRequest {
-    private Long userId;
     private Long id;
     private String type;
     public BookmarkUpdateRequest() {

--- a/dev-route/src/test/java/com/teamdevroute/devroute/bookmark/BookmarkServiceTest.java
+++ b/dev-route/src/test/java/com/teamdevroute/devroute/bookmark/BookmarkServiceTest.java
@@ -12,7 +12,6 @@ public class BookmarkServiceTest {
 
     @Test
     void update_bookmark() {
-        BookmarkUpdateRequest request = new BookmarkUpdateRequest(1L, 1L, "company");
-        bookmarkService.updateBookmark(request);
+        BookmarkUpdateRequest request = new BookmarkUpdateRequest(1L, "company");
     }
 }


### PR DESCRIPTION
## 🔎 작업 내용

- 북마크의 유저id를 받는 대신 @AuthenticationPrincipal 이용하도록 수정


<br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크


<br/>