### PR TITLE
[#80] fix: 기업 검색 시, 해당 기업의 id도 반환하도록 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyResponse.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/dto/CompanyResponse.java
@@ -6,6 +6,7 @@ import lombok.Data;
 
 @Data
 public class CompanyResponse {
+    private Long id;
     private String logoUrl;
     private String name;
     private Long recruitmentCount;
@@ -13,7 +14,8 @@ public class CompanyResponse {
     private String salary;
 
     @Builder
-    public CompanyResponse(String logoUrl, String name, Long recruitmentCount, Double grade, String salary) {
+    public CompanyResponse(Long id, String logoUrl, String name, Long recruitmentCount, Double grade, String salary) {
+        this.id = id;
         this.logoUrl = logoUrl;
         this.name = name;
         this.recruitmentCount = recruitmentCount;
@@ -23,6 +25,7 @@ public class CompanyResponse {
 
     public static CompanyResponse of(Company company) {
         return CompanyResponse.builder()
+                .id(company.getId())
                 .logoUrl(company.getLogoUrl())
                 .name(company.getName())
                 .recruitmentCount(company.getRecruitCount())


### PR DESCRIPTION
## 🔎 작업 내용

- 상세 정보 조회를 위한 id 값이 필요

<br/>

## 🔧 앞으로의 과제



  <br/>

## ➕ 이슈 링크



<br/>