### PR TITLE
fix: CORS 해결을 위한 WebConfig 추가

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/WebConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/WebConfig.java
@@ -1,0 +1,21 @@
+package com.teamdevroute.devroute.global.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.web.servlet.config.annotation.CorsRegistry;
+import org.springframework.web.servlet.config.annotation.WebMvcConfigurer;
+
+@Configuration
+public class WebConfig implements WebMvcConfigurer {
+    @Override
+    public void addCorsMappings(CorsRegistry registry) {
+        registry.addMapping("/**")
+                .allowedOrigins(
+                        "http://localhost:8080",
+                        "http://localhost:3000",
+                        "https://account.google.com"
+                )
+                .allowedMethods("GET", "POST")
+                .allowCredentials(true)
+                .maxAge(3000);
+    }
+}


### PR DESCRIPTION

## 🔎 작업 내용

- WebMvcConfigurer의 addCorsMappings를 구현하여 localhost:3000를 origin으로 허용

<br/>

## 🔧 앞으로의 과제

  <br/>

## ➕ 이슈 링크



<br/>