### PR TITLE
fix: gradle의 서브모듈 카피 코드 수정

### DIFF
--- a/dev-route/build.gradle
+++ b/dev-route/build.gradle
@@ -64,8 +64,12 @@ tasks.named('test') {
 
 processResources.dependsOn('copySecret')
 
-tasks.register('copySecret', Copy) {
-	from '../backend-submodule/application-secret.properties'
-	into 'src/main/resources'
+task copySecret(type: Copy) {
+	from ('../backend-submodule') {
+		include ("*.properties")
+	}
+	into ('./src/main/resources')
 }
+
+
 


### PR DESCRIPTION





## 🔎 작업 내용

- Gradle 8.10 환경에서 Copy에 대한 from, include, into가 인식되지 못하는 에러 발생
- 공식문서를 참고하여 코드를 수정
[Gradle 8.10 Copy](https://docs.gradle.org/current/dsl/org.gradle.api.tasks.Copy.html)


<br/>

## 🔧 앞으로의 과제

- 인프라 배포 및 CI/CD 테스트
  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>