### PR TITLE
security: Tomca에서 https로 전달하도록 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/TomcatConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/TomcatConfig.java
@@ -1,0 +1,16 @@
+package com.teamdevroute.devroute.global.config;
+
+import org.apache.catalina.valves.RemoteIpValve;
+import org.springframework.boot.web.embedded.tomcat.TomcatServletWebServerFactory;
+import org.springframework.boot.web.server.WebServerFactoryCustomizer;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class TomcatConfig {
+
+    @Bean
+    public WebServerFactoryCustomizer<TomcatServletWebServerFactory> tomcatCustomizer() {
+        return factory -> factory.addEngineValves(new RemoteIpValve());
+    }
+}

--- a/dev-route/src/main/resources/application.properties
+++ b/dev-route/src/main/resources/application.properties
@@ -27,3 +27,5 @@ udemy.api.url.search=https://www.udemy.com/api-2.0/courses/?search
 saramin.access-key=rbS6JSH8VQT7y2XoR3B1iOxWfw4u0eMriSgGJnEjHjHQrf6jCtee
 
 logging.level.org.springframework.security=DEBUG
+
+server.forward-headers-strategy=framework


### PR DESCRIPTION
## 🔎 작업 내용

 - Spring Boot가 X-Forwarded-* 헤더를 인식하도록 하며, 프록시나 로드 밸런서에서 전달되는 원래의 프로토콜을 기반으로 리다이렉트를 처리하게 합니다.


<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>