### PR TITLE
fix: 채용공고 크롤링이 매월 1일에 실행되도록 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/CompanyRecruitmentCrawling.java
@@ -24,7 +24,7 @@ public class CompanyRecruitmentCrawling {
         this.recruitmentCrawlingService = recruitmentCrawlingService;
     }
 
-    @Scheduled(cron = "0 0/30 * * * *", zone = "Asia/Seoul")
+    @Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
     public void companyAndRecruitmentCrawling() {
         CrawledCompanyDto crawledCompanyDto = companyCrawling.getCompanyThreePage();
         log.info(crawledCompanyDto.toString());


### PR DESCRIPTION
## 🔎 작업 내용

- `CompanyRecruitmentCrawling`의 `companyAndRecruitmentCrawling()`가 매월 1일 실행되도록 수정
```java
@Scheduled(cron = "0 0 0 1 * *", zone = "Asia/Seoul")
```

<br/>

## 🔧 앞으로의 과제



  <br/>

## ➕ 이슈 링크



<br/>