### PR TITLE
Refactor: videocrawling 관련 리팩토링 및 CI/CD 배포시에 application-prod.propeties가 적용되게 설정

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -48,4 +48,4 @@ jobs:
           key: ${{ secrets.PRIVATE_KEY }}
           script: |
             docker rm -f $(docker ps -qa)
-            docker run -d -p 8080:8080 ${{secrets.DOCKER_REPO}}/devroute-server:${{github.sha}}
+            docker run -d -p 8080:8080 "SPRING_PROFILES_ACTIVE=prod" ${{secrets.DOCKER_REPO}}/devroute-server:${{github.sha}}

--- a/dev-route/src/main/java/com/teamdevroute/devroute/crawling/InfreanVideoCrawling.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/crawling/InfreanVideoCrawling.java
@@ -24,23 +24,23 @@ public class InfreanVideoCrawling {
 
     public ArrayList<InfreanVideoDTO> crawlingInfreanVideo(String teck_stack){
         WebDriver driver = getWebDriver(teck_stack);
-        ArrayList infreanVideoInformaions = new ArrayList<InfreanVideoDTO>();
+        ArrayList infreanVideos = new ArrayList<InfreanVideoDTO>();
         try {
             //WebElement 추출
             List<WebElement> lectures = getLectures(driver);
             // 각 강의 요소를 순회하며 데이터 추출
-            infreanVideoInformaions=getDataInLectureElements(lectures);
+            infreanVideos=getDataInLectureElements(lectures);
         } catch (Exception e) {
             log.error("An unexpected error occurred: " + e.getMessage(), e);
         }
         driver.quit();
-        return infreanVideoInformaions;
+        return infreanVideos;
     }
 
     private ArrayList getDataInLectureElements(List<WebElement> lectures) {
         ArrayList result = new ArrayList<InfreanVideoDTO>();
         for (WebElement lecture : lectures) {
-            if (result.size() >= 12) {
+            if (isMaxSize(result)) {
                 break;
             }
             try {
@@ -55,6 +55,10 @@ public class InfreanVideoCrawling {
             }
         }
         return result;
+    }
+
+    private static boolean isMaxSize(ArrayList result) {
+        return result.size() >= 12;
     }
 
     private String getUrl(WebElement lecture, String cssSelector, String src, String x) {
@@ -91,19 +95,16 @@ public class InfreanVideoCrawling {
             wait.until(ExpectedConditions.presenceOfElementLocated(By.cssSelector("ul.css-y21pja li.mantine-1avyp1d")));
             // 강의 목록 요소를 선택
             List<WebElement> lectures = driver.findElements(By.cssSelector("ul.css-y21pja li.mantine-1avyp1d"));
-
             return lectures;
     }
 
     public WebDriver getWebDriver(String teck_stack) {
-       WebDriverManager.chromedriver().setup();
-//        System.setProperty("chrome.driver", "/chromedriver.exe");
+        WebDriverManager.chromedriver().setup();
         ChromeOptions options = new ChromeOptions();
         options.addArguments("--headless");
         options.addArguments("--no-sandbox");
         options.addArguments("--disable-dev-shm-usage");
         WebDriver driver = new ChromeDriver(options);
-
         switch (teck_stack) {
             case "android":
             case "ios":
@@ -114,15 +115,12 @@ public class InfreanVideoCrawling {
                 driver.get(INFREAN_CRAWRLING_URL_SEARCH_MOBILE_AI + teck_stack + "?types=ONLINE");
                 return driver;
             case "htmlcss":
-                System.out.println(INFREAN_CRAWRLING_URL_SEARCH + "html-css" + "?types=ONLINE");
                 driver.get(INFREAN_CRAWRLING_URL_SEARCH + "html-css" + "&types=ONLINE");
                 return driver;
             case "angular":
-//                System.out.println(INFREAN_CRAWRLING_URL_SEARCH + "html-css" + "?types=ONLINE");
                 driver.get("https://www.inflearn.com/courses?s=angular");
                 return driver;
         }
-
         driver.get(INFREAN_CRAWRLING_URL_SEARCH+teck_stack+"&types=ONLINE");
         return driver;
     }


### PR DESCRIPTION

## 🔎 작업 내용

-  videocrawling 관련하여 리팩토링을 진행함
   - 기존의 크롤링 메서드내에서 진행하던 정보추출을 다른 메서드를 만들어서, 해당 메서드의 테스트 코드를 따로 만들수 있도록 리팩토링 
   -  기존의 불명확하던 변수명 변경

- 운영환경과 개발환경의 분리
  - 기존에는 application-properties내에서 일일히 active=dev를 prod로 바꿔야지만, 해당 코드가 CI/CD가 적용될 때 운영환경의 db가 적용됨
  -  현재는 docker가 빌드 될때 자동으로 application-prod.properties가 적용되어서, 개발환경과 운영환경의 분리가 보다 명확해짐
  


<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

[ (issues/117)](https://github.com/ICT-Dev-Route/Dev-Route-BE/issues/117)

<br/>