### PR TITLE
fix: /healthcheck 요청 시, 필터 통과하도록 설정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
         "/login","/fetch-and-save","/lecture/**", "/signup/**",
         "/token","/roadmap/**","/main/**", "/recruit/**", "/fetch-jobs", "/api/**",
-            "/bookmark/**", "/actuator/**"
+            "/bookmark/**", "/actuator/**, /healthcheck/**"
     };
 
     @PostConstruct


### PR DESCRIPTION
## 🔎 작업 내용

- 20분 정도 간격으로 CPU 사용량이 발생하는 것으로 확인
- 로그 확인 결과 해당 시간대에 EC2의 로드밸런서가 /healthcheck 경로로 헬스체크를 하게 된다.
- /healthcheck 경로에 대해 필터가 작용하는 것을 확인


<br/>

## 🔧 앞으로의 과제


  <br/>

## ➕ 이슈 링크


<br/>