### PR TITLE
fix:Prometheus가 서버 정보를 못가져오는 오류 해결

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/SecurityConfig.java
@@ -39,7 +39,7 @@ public class SecurityConfig {
     private static final String[] AUTH_WHITELIST = {
         "/login","/fetch-and-save","/lecture/**", "/signup/**",
         "/token","/roadmap/**","/main/**", "/recruit/**", "/fetch-jobs", "/api/**",
-            "/bookmark/**", "/actuator/**, /healthcheck/**"
+            "/bookmark/**", "/actuator/**", "/healthcheck/**"
     };
 
     @PostConstruct


### PR DESCRIPTION


## 🔎 작업 내용

- Prometheus가 서버 정보를 못가져오는 오류 해결
    - securityconfig에 있던 Whitelist내에서 url설정이 잘못되어있었음.




<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>