### PR TITLE
fix: ci/cd시 cpu점유율 문제 swap으로 해결

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/config/PasswordEncoderConfig.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/config/PasswordEncoderConfig.java
@@ -6,6 +6,9 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 
 @Configuration
 public class PasswordEncoderConfig {
+
+
+
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
         return new BCryptPasswordEncoder();


### PR DESCRIPTION

## 🔎 작업 내용

- ci/cd시 cpu점유율 문제 swap으로 해결
  -  기존 ec2의 경우 swap메모리 설정이 안되어있어서 CI/CD시 CPU점유율이 많이 올라감

- 구현되었는지 설명해주세요


<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>