### PR TITLE
fix: Company의 name 필드를 unique로 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/company/domain/Company.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/company/domain/Company.java
@@ -21,7 +21,7 @@ public class Company extends BaseTimeEntity {
     @Column(name = "id")
     private Long id;
 
-    @Column(name = "name", nullable = false)
+    @Column(name = "name", nullable = false, unique = true)
     private String name;
 
     @Column(name = "logo_url")


### PR DESCRIPTION
## 🔎 작업 내용

- `RecruitmentUpdateService`의 `parseResponse()` 중 findByName의 결과가 다중 값이 나오는 문제가 발생
- 해당 문제를 해결하기 위해 Company의 name 필드를 unique=true로 수정
🔥기존에 입력된 데이터 중 이름 중복이 포함되어 Company와 Recruitment의 모든 데이터를 지우는 방향으로 추진 예정
<br/>

## 🔧 앞으로의 과제

- 데이터 초기화

  <br/>

## ➕ 이슈 링크

[#125 ](https://github.com/ICT-Dev-Route/Dev-Route-BE/issues/125)

<br/>