### PR TITLE
fix: RecruitmentUpdateService내의 isMaxApiRequest 수정

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentUpdateService.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/recruitment/service/RecruitmentUpdateService.java
@@ -51,7 +51,7 @@ public class RecruitmentUpdateService {
 
 
         try {
-            if(isMaxApiRequest(objectMapper))
+            if(isMaxApiRequest(objectMapper,initialResponse))
                 return;
             int total = objectMapper.readTree(initialResponse).path("jobs").path("total").asInt();
             for (int i = 0; i <= total / 100; i++) {
@@ -65,8 +65,8 @@ public class RecruitmentUpdateService {
         }
     }
 
-    private static boolean isMaxApiRequest(ObjectMapper objectMapper) throws JsonProcessingException {
-        return objectMapper.readTree("message").asText().equals("일일 최대 요청 가능 횟수가 초과되었습니다.");
+    private static boolean isMaxApiRequest(ObjectMapper objectMapper,String initialResponse) throws JsonProcessingException {
+        return objectMapper.readTree(initialResponse).path("message").asText().equals("일일 최대 요청 가능 횟수가 초과되었습니다.");
     }
 
     private void parseAndStoreRecruitment(JsonNode saraminResponses, String keyword) {


### PR DESCRIPTION

## 🔎 작업 내용

-  RecruitmentUpdateService내의 사람인 api를 다 가져왔는지를 반환하는 isMaxRequest 메서드 수정



<br/>

## 🔧 앞으로의 과제

- 내일 할 일을

- 적어주세요

  <br/>

## ➕ 이슈 링크

- [레포 이름 #이슈번호](이슈 주소)

<br/>