### PR TITLE
refactor: FillinStackTrace Overring을 통한 Exception 비용 절감

### DIFF
--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/error/GlobalExceptionHandler.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/error/GlobalExceptionHandler.java
@@ -16,6 +16,7 @@ public class GlobalExceptionHandler {
 
     @ExceptionHandler(DuplicateException.class)
     protected ResponseEntity<ErrorResponse> handleDuplicateException(DuplicateException e) {
+        log.error(e.getMessage(), e);
         final ErrorCodes errorCodes = e.getErrorCodes();
         final String value = e.getValue();
         final int status = HttpStatus.CONFLICT.value();

--- a/dev-route/src/main/java/com/teamdevroute/devroute/global/error/exception/BusinessException.java
+++ b/dev-route/src/main/java/com/teamdevroute/devroute/global/error/exception/BusinessException.java
@@ -17,4 +17,5 @@ public class BusinessException extends RuntimeException {
     public synchronized Throwable fillInStackTrace() {
         return this;
     }
+
 }


### PR DESCRIPTION
## 🔥이슈
- close #139 

## 🔎 작업 내용
### 문제 상황

JVM은 예외가 발생하면 다음과 같이 작동해요.

1. 예외 객체 생성 및 메서드 호출 추적
2. 예외가 발생한 코드에 예외 처리 코드를 탐색. 만약 없으면 상위 메서드로 전파
3. 상위 메서드의 catch 블록을 찾고, 최상위 메서드에도 없는 경우 DefaultExceptionHandler를 통해 예외 처리

이처럼 StackTrace를 통해 **상위 계층으로 전파시키며 정보들을 수집**하는 과정을 가진다. 이때 순회 비용이 무시할 수 없을 정도로 크게 작용한다.

### 해결 방안

단순히 순회를 하는 `FillInStackTrace()를 오버라이딩`한다. 예외를 전파시키지 않고 바로 **자신을 return** 시키므로서 비용을 절감할 수 있다.

NPE, OOP처럼 Java의 기본 예외와 달리 Custom Exception은 목적은 예외 추적이 아닌 **하위 비즈니스 로직의 수행을 막는 것**이다. 따라서 StackTreace를 사용하지 않도록하는 것이 크게 문제되지 않다고 판단했다.

적용 결과, 여러 Exeption이 출력되지 않고, 정확히 CustomException만 출력되는 것을 확인할 수 있다.
![image](https://github.com/user-attachments/assets/c70baf94-9dc4-4381-b384-96caa863a9b1)

<br/>

## 🔧 관련 링크
[Java 예외 생성 비용은 비싸다](https://acoustic-rest-b1b.notion.site/Java-Spring-17b64b4a4ab480f788dcf687003c7d54?pvs=4)
